### PR TITLE
Add commons-compress iterative-AOT cache scripts and CI workflow

### DIFF
--- a/.github/workflows/batik-iterative-aot.yml
+++ b/.github/workflows/batik-iterative-aot.yml
@@ -1,0 +1,115 @@
+name: Batik Iterative AOT Cache
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  iterative-aot:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          submodules: true
+
+      - name: Download iterative-AOT JDK
+        run: |
+          curl -L -o jdk-iterative.tar.gz \
+            "https://github.com/algomaster99/jdk/releases/download/jdk-supply-chain-aotcache-8279d488549/jdk-supply-chain-aotcache-8279d488549.tar.gz"
+
+      - name: Set up iterative-AOT JDK
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: jdkfile
+          java-version: '27'
+          jdkFile: jdk-iterative.tar.gz
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-batik-${{ hashFiles('batik-experiment/**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-batik-
+            ${{ runner.os }}-maven-
+
+      # batik-test-old depends on all batik-* sibling modules, and benchmark
+      # depends on batik-transcoder. Install the full reactor first so both
+      # can resolve their deps from the local Maven repo without network access.
+      - name: Install batik modules into local Maven repo
+        working-directory: batik-experiment/batik
+        run: mvn install -DskipTests -q
+
+      - name: Build benchmark fat jar
+        working-directory: batik-experiment/benchmark
+        run: mvn package -DskipTests -q
+
+      - name: Create cross-workload single-iterjdk.aot caches
+        working-directory: batik-experiment
+        run: |
+          set -euo pipefail
+          chmod +x create-single-aot-iterjdk.sh
+          JAVA_BIN="$JAVA_HOME/bin/java" ./create-single-aot-iterjdk.sh
+          for op in svg-parse svg-to-png svg-to-jpeg svg-generate; do
+            test -f "single-iterjdk-${op}.aot"
+          done
+
+      - name: Create iterative.aot (create-iterative-aot.sh)
+        working-directory: batik-experiment
+        run: |
+          set -euo pipefail
+          chmod +x create-iterative-aot.sh
+          iter_out=$(JAVA_BIN="$JAVA_HOME/bin/java" ./create-iterative-aot.sh 2>&1) || { echo "$iter_out"; exit 1; }
+          echo "$iter_out"
+          iter_out_clean=$(echo "$iter_out" | sed 's/\x1B\[[0-9;]*m//g')
+
+          iter_size=$(du -h iterative.aot | awk '{print $1}')
+
+          {
+            echo "## iterative.aot creation"
+            echo
+            echo "- iterative.aot: ${iter_size}"
+            echo
+            echo '```'
+            echo "$iter_out_clean"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          test -f iterative.aot
+
+      - name: Run timed workload (no vs aotcache vs iterative)
+        working-directory: batik-experiment
+        run: |
+          set -euo pipefail
+          chmod +x workload-timed-iterative.sh
+          wl_out=$(JAVA_BIN="$JAVA_HOME/bin/java" ./workload-timed-iterative.sh 2>&1) || { echo "$wl_out"; exit 1; }
+          echo "$wl_out"
+          wl_out_clean=$(echo "$wl_out" | sed 's/\x1B\[[0-9;]*m//g')
+
+          single_size=$(du -ch single-iterjdk-*.aot | tail -1 | awk '{print $1}')
+          iter_size=$(du -h iterative.aot | awk '{print $1}')
+
+          {
+            echo "## Timed workload results (no vs cross-workload aotcache vs iterative)"
+            echo
+            echo "- single-iterjdk-*.aot total: ${single_size}"
+            echo "- iterative.aot: ${iter_size}"
+            echo
+            echo '```'
+            echo "$wl_out_clean"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Batik iterative-AOT artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: batik-iterative-artifacts
+          path: |
+            batik-experiment/workload-tmp/
+            batik-experiment/single-iterjdk-*.aot
+            batik-experiment/iterative-step*.aot
+            batik-experiment/iterative.aot
+          if-no-files-found: error

--- a/.github/workflows/commons-compress-iterative-aot.yml
+++ b/.github/workflows/commons-compress-iterative-aot.yml
@@ -1,0 +1,107 @@
+name: Commons Compress Iterative AOT Cache
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  iterative-aot:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          submodules: true
+
+      - name: Download iterative-AOT JDK
+        run: |
+          curl -L -o jdk-iterative.tar.gz \
+            "https://github.com/algomaster99/jdk/releases/download/jdk-supply-chain-aotcache-8279d488549/jdk-supply-chain-aotcache-8279d488549.tar.gz"
+
+      - name: Set up iterative-AOT JDK
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: jdkfile
+          java-version: '25'
+          jdkFile: jdk-iterative.tar.gz
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Build benchmark jar
+        working-directory: commons-compress-experiment/benchmark
+        run: mvn package -DskipTests -q
+
+      - name: Create cross-workload single-iterjdk.aot caches
+        working-directory: commons-compress-experiment
+        run: |
+          set -euo pipefail
+          chmod +x create-single-aot-iterjdk.sh
+          JAVA_BIN="$JAVA_HOME/bin/java" ./create-single-aot-iterjdk.sh
+          for op in gzip-roundtrip zip-roundtrip tar-roundtrip list-archives; do
+            test -f "single-iterjdk-${op}.aot"
+          done
+
+      - name: Create iterative.aot (create-iterative-aot.sh)
+        working-directory: commons-compress-experiment
+        run: |
+          set -euo pipefail
+          chmod +x create-iterative-aot.sh
+          iter_out=$(JAVA_BIN="$JAVA_HOME/bin/java" ./create-iterative-aot.sh 2>&1) || { echo "$iter_out"; exit 1; }
+          echo "$iter_out"
+          iter_out_clean=$(echo "$iter_out" | sed 's/\x1B\[[0-9;]*m//g')
+
+          iter_size=$(du -h iterative.aot | awk '{print $1}')
+
+          {
+            echo "## iterative.aot creation"
+            echo
+            echo "- iterative.aot: ${iter_size}"
+            echo
+            echo '```'
+            echo "$iter_out_clean"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          test -f iterative.aot
+
+      - name: Run timed workload (no vs aotcache vs iterative)
+        working-directory: commons-compress-experiment
+        run: |
+          set -euo pipefail
+          chmod +x workload-timed-iterative.sh
+          wl_out=$(JAVA_BIN="$JAVA_HOME/bin/java" ./workload-timed-iterative.sh 2>&1) || { echo "$wl_out"; exit 1; }
+          echo "$wl_out"
+          wl_out_clean=$(echo "$wl_out" | sed 's/\x1B\[[0-9;]*m//g')
+
+          single_size=$(du -ch single-iterjdk-*.aot | tail -1 | awk '{print $1}')
+          iter_size=$(du -h iterative.aot | awk '{print $1}')
+
+          {
+            echo "## Timed workload results (no vs cross-workload aotcache vs iterative)"
+            echo
+            echo "- single-iterjdk-*.aot total: ${single_size}"
+            echo "- iterative.aot: ${iter_size}"
+            echo
+            echo '```'
+            echo "$wl_out_clean"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Commons Compress iterative-AOT artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: commons-compress-iterative-artifacts
+          path: |
+            commons-compress-experiment/workload-tmp/
+            commons-compress-experiment/single-iterjdk-*.aot
+            commons-compress-experiment/iterative-step*.aot
+            commons-compress-experiment/iterative.aot
+          if-no-files-found: error

--- a/.github/workflows/commons-compress-iterative-aot.yml
+++ b/.github/workflows/commons-compress-iterative-aot.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
         with:
           distribution: jdkfile
-          java-version: '25'
+          java-version: '27'
           jdkFile: jdk-iterative.tar.gz
 
       - name: Cache Maven dependencies

--- a/.github/workflows/pdfbox-iterative-aot.yml
+++ b/.github/workflows/pdfbox-iterative-aot.yml
@@ -1,0 +1,107 @@
+name: PDFBox Iterative AOT Cache
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  iterative-aot:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          submodules: true
+
+      - name: Download iterative-AOT JDK
+        run: |
+          curl -L -o jdk-iterative.tar.gz \
+            "https://github.com/algomaster99/jdk/releases/download/jdk-supply-chain-aotcache-8279d488549/jdk-supply-chain-aotcache-8279d488549.tar.gz"
+
+      - name: Set up iterative-AOT JDK
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: jdkfile
+          java-version: '27'
+          jdkFile: jdk-iterative.tar.gz
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Build pdfbox app jar
+        working-directory: pdfbox-experiment/pdfbox
+        run: mvn package -DskipTests -q
+
+      - name: Create cross-workload single-iterjdk.aot caches
+        working-directory: pdfbox-experiment
+        run: |
+          set -euo pipefail
+          chmod +x create-single-aot-iterjdk.sh
+          JAVA_BIN="$JAVA_HOME/bin/java" ./create-single-aot-iterjdk.sh
+          for op in export-text export-images render fromtext split merge decode overlay; do
+            test -f "single-iterjdk-${op}.aot"
+          done
+
+      - name: Create iterative.aot (create-iterative-aot.sh)
+        working-directory: pdfbox-experiment
+        run: |
+          set -euo pipefail
+          chmod +x create-iterative-aot.sh
+          iter_out=$(JAVA_BIN="$JAVA_HOME/bin/java" ./create-iterative-aot.sh 2>&1) || { echo "$iter_out"; exit 1; }
+          echo "$iter_out"
+          iter_out_clean=$(echo "$iter_out" | sed 's/\x1B\[[0-9;]*m//g')
+
+          iter_size=$(du -h iterative.aot | awk '{print $1}')
+
+          {
+            echo "## iterative.aot creation"
+            echo
+            echo "- iterative.aot: ${iter_size}"
+            echo
+            echo '```'
+            echo "$iter_out_clean"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          test -f iterative.aot
+
+      - name: Run timed workload (no vs aotcache vs iterative)
+        working-directory: pdfbox-experiment
+        run: |
+          set -euo pipefail
+          chmod +x workload-timed-iterative.sh
+          wl_out=$(JAVA_BIN="$JAVA_HOME/bin/java" ./workload-timed-iterative.sh 2>&1) || { echo "$wl_out"; exit 1; }
+          echo "$wl_out"
+          wl_out_clean=$(echo "$wl_out" | sed 's/\x1B\[[0-9;]*m//g')
+
+          single_size=$(du -ch single-iterjdk-*.aot | tail -1 | awk '{print $1}')
+          iter_size=$(du -h iterative.aot | awk '{print $1}')
+
+          {
+            echo "## Timed workload results (no vs cross-workload aotcache vs iterative)"
+            echo
+            echo "- single-iterjdk-*.aot total: ${single_size}"
+            echo "- iterative.aot: ${iter_size}"
+            echo
+            echo '```'
+            echo "$wl_out_clean"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload PDFBox iterative-AOT artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: pdfbox-iterative-artifacts
+          path: |
+            pdfbox-experiment/workload-tmp/
+            pdfbox-experiment/single-iterjdk-*.aot
+            pdfbox-experiment/iterative-step*.aot
+            pdfbox-experiment/iterative.aot
+          if-no-files-found: error

--- a/batik-experiment/create-iterative-aot.sh
+++ b/batik-experiment/create-iterative-aot.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Builds an AOT cache incrementally, one workload at a time, using the
+# one-step "-XX:AOTCache=<base> -XX:AOTCacheOutput=<next>" workflow added in
+# https://github.com/openjdk/jdk/pull/31344 ("iterative training for AOT
+# one-step workflow"). Each step loads the cache produced by the previous
+# step as its base and folds the new workload's classes into the output —
+# no AOTMode=record/create/merge needed, and no AOTMode=merge support is
+# required from the JDK (the build under test does not have it).
+#
+# Point JAVA_BIN at the JDK build that contains the PR before running, e.g.:
+#   JAVA_BIN=~/Desktop/tools/jdk/build/linux-x86_64-server-release-aot-re-training/images/jdk/bin/java \
+#     ./create-iterative-aot.sh
+set -euo pipefail
+
+log()  { echo -e "\033[1;32m[$(date '+%H:%M:%S')] $*\033[0m"; }
+fail() { echo -e "\033[1;31mERROR: $*\033[0m" >&2; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+JAVA_BIN="${JAVA_BIN:-java}"
+FAT_JAR="benchmark/target/benchmark-fat.jar"
+MAIN="dev.batikexp.Main"
+WORK_DIR="workload-tmp"
+JAVA_ARGS=(-Djava.awt.headless=true -cp "$FAT_JAR")
+
+log "Java binary: $JAVA_BIN"
+"$JAVA_BIN" -version
+
+[[ -f "$FAT_JAR" ]] || fail "$FAT_JAR not found — run: cd benchmark && mvn package -DskipTests"
+
+# Training order for the iterative cache.
+OPS=(svg-parse svg-to-png svg-to-jpeg svg-generate)
+
+mkdir -p "$WORK_DIR"
+"$JAVA_BIN" "${JAVA_ARGS[@]}" "$MAIN" prepare "$WORK_DIR"
+
+prev_aot=""
+for i in "${!OPS[@]}"; do
+  op="${OPS[$i]}"
+  step=$(( i + 1 ))
+  out_aot="iterative-step${step}-${op}.aot"
+
+  if [ -f "$out_aot" ]; then
+    log "$out_aot already exists, skipping."
+    prev_aot="$out_aot"
+    continue
+  fi
+
+  base_args=()
+  if [ -n "$prev_aot" ]; then
+    base_args=(-XX:AOTCache="$prev_aot")
+    log "Step $step: folding '$op' into $prev_aot -> $out_aot"
+  else
+    log "Step $step: training '$op' from scratch -> $out_aot"
+  fi
+
+  "$JAVA_BIN" \
+    "${base_args[@]}" \
+    -XX:AOTCacheOutput="$out_aot" \
+    -XX:+AOTClassLinking \
+    "${JAVA_ARGS[@]}" "$MAIN" "$op" "$WORK_DIR"
+
+  test -f "$out_aot"
+  log "$out_aot created ($(du -sh "$out_aot" | cut -f1))"
+  prev_aot="$out_aot"
+done
+
+cp -f "$prev_aot" iterative.aot
+log "Final iterative cache: iterative.aot (copy of $prev_aot)"

--- a/batik-experiment/create-single-aot-iterjdk.sh
+++ b/batik-experiment/create-single-aot-iterjdk.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Same as create-single-aot.sh, but built with a configurable JAVA_BIN and
+# written to single-iterjdk-{op}.aot so caches built with the iterative-AOT
+# JDK build (PR 31344) don't collide with the single-{op}.aot files already
+# built with the stock JDK for the original experiment.
+set -euo pipefail
+
+log()  { echo -e "\033[1;32m[$(date '+%H:%M:%S')] $*\033[0m"; }
+fail() { echo -e "\033[1;31mERROR: $*\033[0m" >&2; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+JAVA_BIN="${JAVA_BIN:-java}"
+FAT_JAR="benchmark/target/benchmark-fat.jar"
+MAIN="dev.batikexp.Main"
+WORK_DIR="workload-tmp"
+OPS=(svg-parse svg-to-png svg-to-jpeg svg-generate)
+JAVA_ARGS=(-Djava.awt.headless=true -cp "$FAT_JAR")
+
+log "Java binary: $JAVA_BIN"
+"$JAVA_BIN" -version
+
+[[ -f "$FAT_JAR" ]] || fail "$FAT_JAR not found — run: cd benchmark && mvn package -DskipTests"
+
+mkdir -p "$WORK_DIR"
+log "Preparing workload inputs"
+"$JAVA_BIN" "${JAVA_ARGS[@]}" "$MAIN" prepare "$WORK_DIR"
+
+for op in "${OPS[@]}"; do
+  aot="single-iterjdk-${op}.aot"
+  conf="single-iterjdk-${op}.aotconf"
+  if [[ -f "$aot" ]]; then
+    log "$aot already exists, skipping."
+    continue
+  fi
+  log "Creating $aot (training op: $op)"
+  rm -f "$conf"
+  "$JAVA_BIN" -XX:AOTMode=record -XX:AOTConfiguration="$conf" \
+    -XX:+AOTClassLinking \
+    "${JAVA_ARGS[@]}" "$MAIN" "$op" "$WORK_DIR"
+  [[ -f "$conf" ]] || fail "AOT configuration file was not produced for op=$op"
+  "$JAVA_BIN" -XX:AOTMode=create \
+    -XX:AOTConfiguration="$conf" \
+    -XX:AOTCache="$aot" \
+    -XX:+AOTClassLinking \
+    "${JAVA_ARGS[@]}"
+  [[ -f "$aot" ]] || fail "$aot was not created"
+  log "$aot created ($(du -sh "$aot" | cut -f1))"
+done

--- a/batik-experiment/workload-timed-iterative.sh
+++ b/batik-experiment/workload-timed-iterative.sh
@@ -5,7 +5,7 @@
 #               other three ops, run on this one) — same shape as the
 #               original cross-workload test, rebuilt for this JDK build
 #   iterative — iterative.aot, built incrementally by create-iterative-aot.sh
-#               (gzip -> zip -> tar -> list-archives, each step folded into the next)
+#               (svg-parse -> svg-to-png -> svg-to-jpeg -> svg-generate)
 #
 # Point JAVA_BIN at the JDK build under test, e.g.:
 #   JAVA_BIN=~/Desktop/tools/jdk/build/linux-x86_64-server-release-aot-re-training/images/jdk/bin/java \
@@ -20,23 +20,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
 JAVA_BIN="${JAVA_BIN:-java}"
-JAR="benchmark/target/original-benchmark-1.0-SNAPSHOT.jar"
-DEPS_DIR="single-aot-deps"
-# single-iterjdk-{op}.aot and iterative.aot are both recorded against JARs
-# (CDS dump rejects non-empty directory classpath entries) — use the
-# matching JAR-based classpath for all run modes here.
-CP="$JAR:\
-$DEPS_DIR/commons-compress-1.28.0.jar:\
-$DEPS_DIR/commons-lang3-3.20.0.jar:\
-$DEPS_DIR/commons-codec-1.21.0.jar:\
-$DEPS_DIR/commons-io-2.20.0.jar"
-MAIN="dev.compressexp.Main"
+FAT_JAR="benchmark/target/benchmark-fat.jar"
+MAIN="dev.batikexp.Main"
 WORK_DIR="workload-tmp"
 ITERATIVE_AOT="iterative.aot"
 RUNS="${RUNS:-30}"
-OPS=("gzip-roundtrip" "zip-roundtrip" "tar-roundtrip" "list-archives")
+OPS=(svg-parse svg-to-png svg-to-jpeg svg-generate)
+JAVA_ARGS=(-Djava.awt.headless=true -cp "$FAT_JAR")
 
-[[ -f "$JAR" ]] || fail "$JAR not found — run: cd benchmark && mvn package -DskipTests"
+[[ -f "$FAT_JAR" ]] || fail "$FAT_JAR not found — run: cd benchmark && mvn package -DskipTests"
 [[ -f "$ITERATIVE_AOT" ]] || fail "$ITERATIVE_AOT not found — run create-iterative-aot.sh first"
 for _op in "${OPS[@]}"; do
   [[ -f "single-iterjdk-${_op}.aot" ]] || fail "single-iterjdk-${_op}.aot not found — run create-single-aot-iterjdk.sh first"
@@ -47,7 +39,7 @@ mkdir -p "$WORK_DIR"
 log "Java binary under test: $JAVA_BIN"
 "$JAVA_BIN" -version
 
-"$JAVA_BIN" -cp "$CP" "$MAIN" prepare "$WORK_DIR" >/dev/null
+"$JAVA_BIN" "${JAVA_ARGS[@]}" "$MAIN" prepare "$WORK_DIR" >/dev/null
 
 ms() { date +%s%N | awk '{printf "%.1f", $1/1000000}'; }
 
@@ -74,20 +66,20 @@ stddev_for_key() {
 
 run_no() {
   local op="$1"
-  "$JAVA_BIN" -cp "$CP" "$MAIN" "$op" "$WORK_DIR"
+  "$JAVA_BIN" "${JAVA_ARGS[@]}" "$MAIN" "$op" "$WORK_DIR"
 }
 
 # train_op determines which single-iterjdk-{op}.aot to load; test_op is the workload run.
 run_aotcache_cross() {
   local train_op="$1" test_op="$2"
   "$JAVA_BIN" -XX:AOTCache="single-iterjdk-${train_op}.aot" -XX:+AOTClassLinking \
-    -cp "$CP" "$MAIN" "$test_op" "$WORK_DIR"
+    "${JAVA_ARGS[@]}" "$MAIN" "$test_op" "$WORK_DIR"
 }
 
 run_iterative() {
   local op="$1"
   "$JAVA_BIN" -XX:AOTCache="$ITERATIVE_AOT" -XX:+AOTClassLinking \
-    -cp "$CP" "$MAIN" "$op" "$WORK_DIR"
+    "${JAVA_ARGS[@]}" "$MAIN" "$op" "$WORK_DIR"
 }
 
 measure_ms() {
@@ -133,7 +125,7 @@ test_stddev_aotcache() {
     END { if (n < 2) { print "n/a" } else { printf "%.1f", sqrt((sumsq - sum*sum/n) / (n-1)) } }'
 }
 
-log "Running Commons Compress iterative-AOT workload RUNS=$RUNS"
+log "Running Batik iterative-AOT workload RUNS=$RUNS"
 for RUN_IDX in $(seq 1 "$RUNS"); do
   printf "  run %2d/%d\n" "$RUN_IDX" "$RUNS"
   # no and iterative: one pass over all ops
@@ -178,19 +170,19 @@ print_class_load_row() {
   case "$mode" in
     no)
       "$JAVA_BIN" -Xlog:class+load:file="$classload_log" \
-        -cp "$CP" "$MAIN" "$op" "$WORK_DIR"
+        "${JAVA_ARGS[@]}" "$MAIN" "$op" "$WORK_DIR"
       ;;
     aotcache)
       "$JAVA_BIN" -XX:AOTCache="single-iterjdk-${op}.aot" \
         -XX:+AOTClassLinking \
         -Xlog:class+load:file="$classload_log" \
-        -cp "$CP" "$MAIN" "$op" "$WORK_DIR"
+        "${JAVA_ARGS[@]}" "$MAIN" "$op" "$WORK_DIR"
       ;;
     iterative)
       "$JAVA_BIN" -XX:AOTCache="$ITERATIVE_AOT" \
         -XX:+AOTClassLinking \
         -Xlog:class+load:file="$classload_log" \
-        -cp "$CP" "$MAIN" "$op" "$WORK_DIR"
+        "${JAVA_ARGS[@]}" "$MAIN" "$op" "$WORK_DIR"
       ;;
   esac
   printf "  %-16s | %-9s | %8s | %8s\n" \

--- a/commons-compress-experiment/create-iterative-aot.sh
+++ b/commons-compress-experiment/create-iterative-aot.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Builds an AOT cache incrementally, one workload at a time, using the
+# one-step "-XX:AOTCache=<base> -XX:AOTCacheOutput=<next>" workflow added in
+# https://github.com/openjdk/jdk/pull/31344 ("iterative training for AOT
+# one-step workflow"). Each step loads the cache produced by the previous
+# step as its base and folds the new workload's classes into the output —
+# no AOTMode=record/create/merge needed, and no AOTMode=merge support is
+# required from the JDK (the build under test does not have it).
+#
+# Point JAVA_BIN at the JDK build that contains the PR before running, e.g.:
+#   JAVA_BIN=~/Desktop/tools/jdk/build/linux-x86_64-server-release-aot-re-training/images/jdk/bin/java \
+#     ./create-iterative-aot.sh
+set -euo pipefail
+
+log() { echo -e "\033[1;32m[$(date '+%H:%M:%S')] $*\033[0m"; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+JAVA_BIN="${JAVA_BIN:-java}"
+BENCH_JAR="benchmark/target/original-benchmark-1.0-SNAPSHOT.jar"
+DEPS_DIR="single-aot-deps"
+MAIN="dev.compressexp.Main"
+WORK_DIR="workload-tmp"
+
+log "Java binary: $JAVA_BIN"
+"$JAVA_BIN" -version
+
+# CDS dump (the one-step AOTCacheOutput flow does record+create internally)
+# rejects non-empty directory classpath entries, so this must use the
+# JAR-based classpath (already downloaded by create-single-aot.sh).
+CP="$BENCH_JAR:\
+$DEPS_DIR/commons-compress-1.28.0.jar:\
+$DEPS_DIR/commons-lang3-3.20.0.jar:\
+$DEPS_DIR/commons-codec-1.21.0.jar:\
+$DEPS_DIR/commons-io-2.20.0.jar"
+
+[[ -f "$BENCH_JAR" ]] || { echo "Missing $BENCH_JAR (build benchmark first)" >&2; exit 1; }
+
+# Training order for the iterative cache: gzip -> zip -> tar -> list-archives.
+OPS=("gzip-roundtrip" "zip-roundtrip" "tar-roundtrip" "list-archives")
+
+mkdir -p "$WORK_DIR"
+"$JAVA_BIN" -cp "$CP" "$MAIN" prepare "$WORK_DIR"
+
+prev_aot=""
+for i in "${!OPS[@]}"; do
+  op="${OPS[$i]}"
+  step=$(( i + 1 ))
+  out_aot="iterative-step${step}-${op}.aot"
+
+  if [ -f "$out_aot" ]; then
+    log "$out_aot already exists, skipping."
+    prev_aot="$out_aot"
+    continue
+  fi
+
+  base_args=()
+  if [ -n "$prev_aot" ]; then
+    base_args=(-XX:AOTCache="$prev_aot")
+    log "Step $step: folding '$op' into $prev_aot -> $out_aot"
+  else
+    log "Step $step: training '$op' from scratch -> $out_aot"
+  fi
+
+  "$JAVA_BIN" \
+    "${base_args[@]}" \
+    -XX:AOTCacheOutput="$out_aot" \
+    -XX:+AOTClassLinking \
+    -cp "$CP" "$MAIN" "$op" "$WORK_DIR"
+
+  test -f "$out_aot"
+  log "$out_aot created ($(du -sh "$out_aot" | cut -f1))"
+  prev_aot="$out_aot"
+done
+
+cp -f "$prev_aot" iterative.aot
+log "Final iterative cache: iterative.aot (copy of $prev_aot)"

--- a/commons-compress-experiment/create-single-aot-iterjdk.sh
+++ b/commons-compress-experiment/create-single-aot-iterjdk.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Same as create-single-aot.sh, but built with a configurable JAVA_BIN and
+# written to single-iterjdk-{op}.aot so caches built with the iterative-AOT
+# JDK build (PR 31344) don't collide with the single-{op}.aot files already
+# built with the stock JDK for the original experiment.
+set -euo pipefail
+
+log() { echo -e "\033[1;32m[$(date '+%H:%M:%S')] $*\033[0m"; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+JAVA_BIN="${JAVA_BIN:-java}"
+BENCH_JAR="benchmark/target/original-benchmark-1.0-SNAPSHOT.jar"
+DEPS_DIR="single-aot-deps"
+MAIN="dev.compressexp.Main"
+WORK_DIR="workload-tmp"
+
+log "Java binary: $JAVA_BIN"
+"$JAVA_BIN" -version
+
+OPS=("gzip-roundtrip" "zip-roundtrip" "tar-roundtrip" "list-archives")
+
+[[ -f "$BENCH_JAR" ]] || { echo "Missing $BENCH_JAR (build benchmark first)" >&2; exit 1; }
+
+# CDS dump (record/create) rejects non-empty directory classpath entries, so
+# this must use the JAR-based classpath (already downloaded by create-single-aot.sh).
+CP="$BENCH_JAR:\
+$DEPS_DIR/commons-compress-1.28.0.jar:\
+$DEPS_DIR/commons-lang3-3.20.0.jar:\
+$DEPS_DIR/commons-codec-1.21.0.jar:\
+$DEPS_DIR/commons-io-2.20.0.jar"
+
+mkdir -p "$WORK_DIR"
+"$JAVA_BIN" -cp "$CP" "$MAIN" prepare "$WORK_DIR"
+
+for op in "${OPS[@]}"; do
+  aot="single-iterjdk-${op}.aot"
+  conf="single-iterjdk-${op}.aotconf"
+  if [ -f "$aot" ]; then
+    log "$aot already exists, skipping."
+    continue
+  fi
+  log "Creating $aot (training op: $op)"
+  rm -f "$conf"
+  "$JAVA_BIN" -XX:AOTMode=record -XX:AOTConfiguration="$conf" \
+    -XX:+AOTClassLinking \
+    -cp "$CP" "$MAIN" "$op" "$WORK_DIR"
+  test -f "$conf"
+  "$JAVA_BIN" -XX:AOTMode=create -XX:AOTConfiguration="$conf" \
+    -XX:AOTCache="$aot" \
+    -XX:+AOTClassLinking \
+    -cp "$CP"
+  test -f "$aot"
+  log "$aot created."
+done

--- a/commons-compress-experiment/create-single-aot-iterjdk.sh
+++ b/commons-compress-experiment/create-single-aot-iterjdk.sh
@@ -23,8 +23,31 @@ OPS=("gzip-roundtrip" "zip-roundtrip" "tar-roundtrip" "list-archives")
 
 [[ -f "$BENCH_JAR" ]] || { echo "Missing $BENCH_JAR (build benchmark first)" >&2; exit 1; }
 
+# *.jar is gitignored, so single-aot-deps/ is empty on a clean checkout (e.g. CI).
+MAVEN_CENTRAL="https://repo1.maven.org/maven2"
+declare -a DEP_JARS=(
+  "commons-compress-1.28.0.jar"
+  "commons-lang3-3.20.0.jar"
+  "commons-codec-1.21.0.jar"
+  "commons-io-2.20.0.jar"
+)
+declare -a DEP_URLS=(
+  "$MAVEN_CENTRAL/org/apache/commons/commons-compress/1.28.0/commons-compress-1.28.0.jar"
+  "$MAVEN_CENTRAL/org/apache/commons/commons-lang3/3.20.0/commons-lang3-3.20.0.jar"
+  "$MAVEN_CENTRAL/commons-codec/commons-codec/1.21.0/commons-codec-1.21.0.jar"
+  "$MAVEN_CENTRAL/commons-io/commons-io/2.20.0/commons-io-2.20.0.jar"
+)
+mkdir -p "$DEPS_DIR"
+for i in "${!DEP_JARS[@]}"; do
+  dest="$DEPS_DIR/${DEP_JARS[$i]}"
+  if [ ! -f "$dest" ]; then
+    log "Downloading ${DEP_JARS[$i]}"
+    curl -fsSL "${DEP_URLS[$i]}" -o "$dest"
+  fi
+done
+
 # CDS dump (record/create) rejects non-empty directory classpath entries, so
-# this must use the JAR-based classpath (already downloaded by create-single-aot.sh).
+# this must use the JAR-based classpath.
 CP="$BENCH_JAR:\
 $DEPS_DIR/commons-compress-1.28.0.jar:\
 $DEPS_DIR/commons-lang3-3.20.0.jar:\

--- a/commons-compress-experiment/workload-timed-iterative.sh
+++ b/commons-compress-experiment/workload-timed-iterative.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+# Timing comparison for the iterative-AOT JDK build (PR 31344). Three modes:
+#   no        — no AOT cache
+#   aotcache  — single-iterjdk-{op}.aot cross-workload (cache trained on the
+#               other three ops, run on this one) — same shape as the
+#               original cross-workload test, rebuilt for this JDK build
+#   iterative — iterative.aot, built incrementally by create-iterative-aot.sh
+#               (gzip -> zip -> tar -> list-archives, each step folded into the next)
+#
+# Point JAVA_BIN at the JDK build under test, e.g.:
+#   JAVA_BIN=~/Desktop/tools/jdk/build/linux-x86_64-server-release-aot-re-training/images/jdk/bin/java \
+#     ./workload-timed-iterative.sh
+set -euo pipefail
+
+log()  { echo -e "\033[1;32m[$(date '+%H:%M:%S')] $*\033[0m"; }
+sep()  { echo -e "\033[0;90m  $(printf '─%.0s' {1..60})\033[0m"; }
+fail() { echo -e "\033[1;31mERROR: $*\033[0m" >&2; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+JAVA_BIN="${JAVA_BIN:-java}"
+JAR="benchmark/target/original-benchmark-1.0-SNAPSHOT.jar"
+DEPS_DIR="single-aot-deps"
+# single-iterjdk-{op}.aot and iterative.aot are both recorded against JARs
+# (CDS dump rejects non-empty directory classpath entries) — use the
+# matching JAR-based classpath for all run modes here.
+CP="$JAR:\
+$DEPS_DIR/commons-compress-1.28.0.jar:\
+$DEPS_DIR/commons-lang3-3.20.0.jar:\
+$DEPS_DIR/commons-codec-1.21.0.jar:\
+$DEPS_DIR/commons-io-2.20.0.jar"
+MAIN="dev.compressexp.Main"
+WORK_DIR="workload-tmp"
+ITERATIVE_AOT="iterative.aot"
+RUNS="${RUNS:-30}"
+OPS=("gzip-roundtrip" "zip-roundtrip" "tar-roundtrip" "list-archives")
+
+[[ -f "$JAR" ]] || fail "$JAR not found — run: cd benchmark && mvn package -DskipTests"
+[[ -f "$ITERATIVE_AOT" ]] || fail "$ITERATIVE_AOT not found — run create-iterative-aot.sh first"
+for _op in "${OPS[@]}"; do
+  [[ -f "single-iterjdk-${_op}.aot" ]] || fail "single-iterjdk-${_op}.aot not found — run create-single-aot-iterjdk.sh first"
+done
+
+mkdir -p "$WORK_DIR"
+
+log "Java binary under test: $JAVA_BIN"
+"$JAVA_BIN" -version
+
+"$JAVA_BIN" -cp "$CP" "$MAIN" prepare "$WORK_DIR" >/dev/null
+
+ms() { date +%s%N | awk '{printf "%.1f", $1/1000000}'; }
+
+declare -A samples
+
+update_stats() {
+  local key="$1" sample_ms="$2"
+  samples[$key]="${samples[$key]:-} ${sample_ms}"
+}
+
+mean_for_key() {
+  local values="${samples[$1]# }"
+  printf "%s\n" $values | awk '
+    { sum += $1; n++ }
+    END { if (n == 0) { print "n/a" } else { printf "%.1f", sum/n } }'
+}
+
+stddev_for_key() {
+  local values="${samples[$1]# }"
+  printf "%s\n" $values | awk '
+    { sum += $1; sumsq += $1*$1; n++ }
+    END { if (n < 2) { print "n/a" } else { printf "%.1f", sqrt((sumsq - sum*sum/n) / (n-1)) } }'
+}
+
+run_no() {
+  local op="$1"
+  "$JAVA_BIN" -cp "$CP" "$MAIN" "$op" "$WORK_DIR"
+}
+
+# train_op determines which single-iterjdk-{op}.aot to load; test_op is the workload run.
+run_aotcache_cross() {
+  local train_op="$1" test_op="$2"
+  "$JAVA_BIN" -XX:AOTCache="single-iterjdk-${train_op}.aot" -XX:+AOTClassLinking \
+    -cp "$CP" "$MAIN" "$test_op" "$WORK_DIR"
+}
+
+run_iterative() {
+  local op="$1"
+  "$JAVA_BIN" -XX:AOTCache="$ITERATIVE_AOT" -XX:+AOTClassLinking \
+    -cp "$CP" "$MAIN" "$op" "$WORK_DIR"
+}
+
+measure_ms() {
+  local label_op="$1" label_mode="$2"
+  shift 2
+  local file_label_op="${label_op//>/-to-}"
+  local err_file="$WORK_DIR/${RUN_IDX:-0}-${file_label_op}-${label_mode}.stderr.log"
+  local start end rc
+  start=$(ms)
+  "$@" >/dev/null 2>"$err_file"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "ERROR: failed (op=$label_op mode=$label_mode rc=$rc) see $err_file" >&2
+    return "$rc"
+  fi
+  end=$(ms)
+  awk "BEGIN {printf \"%.1f\", $end - $start}"
+}
+
+# Mean time of test_op when run with caches trained on each other op.
+test_mean_aotcache() {
+  local test_op="$1" sum=0 n=0 train_op key m
+  for train_op in "${OPS[@]}"; do
+    [[ "$train_op" == "$test_op" ]] && continue
+    key="${train_op}|${test_op}|aotcache"
+    m=$(mean_for_key "$key")
+    sum=$(awk "BEGIN{printf \"%.4f\", $sum + $m}")
+    n=$(( n + 1 ))
+  done
+  awk -v s="$sum" -v n="$n" 'BEGIN{printf "%.1f", s/n}'
+}
+
+# Pooled SD of test_op across all caches trained on other ops.
+test_stddev_aotcache() {
+  local test_op="$1" all_samples="" train_op key
+  for train_op in "${OPS[@]}"; do
+    [[ "$train_op" == "$test_op" ]] && continue
+    key="${train_op}|${test_op}|aotcache"
+    all_samples="$all_samples ${samples[$key]:-}"
+  done
+  printf "%s\n" $all_samples | awk '
+    { sum += $1; sumsq += $1*$1; n++ }
+    END { if (n < 2) { print "n/a" } else { printf "%.1f", sqrt((sumsq - sum*sum/n) / (n-1)) } }'
+}
+
+log "Running Commons Compress iterative-AOT workload RUNS=$RUNS"
+for RUN_IDX in $(seq 1 "$RUNS"); do
+  printf "  run %2d/%d\n" "$RUN_IDX" "$RUNS"
+  # no and iterative: one pass over all ops
+  for op in "${OPS[@]}"; do
+    update_stats "${op}|no"        "$(measure_ms "$op" "no"        run_no        "$op")"
+    update_stats "${op}|iterative" "$(measure_ms "$op" "iterative" run_iterative "$op")"
+  done
+  # aotcache cross-workload: for each training op, run its cache on all other ops
+  for train_op in "${OPS[@]}"; do
+    for test_op in "${OPS[@]}"; do
+      [[ "$test_op" == "$train_op" ]] && continue
+      update_stats "${train_op}|${test_op}|aotcache" \
+        "$(measure_ms "${train_op}>${test_op}" "aotcache" run_aotcache_cross "$train_op" "$test_op")"
+    done
+  done
+done
+
+echo
+log "Per-workload timing over ${RUNS} runs (ms)"
+sep
+printf "  %-16s | %18s | %20s %8s | %20s %8s\n" \
+  "Workload" "no (mean±SD)" "aotcache (mean±SD)" "su-aotcache" "iterative (mean±SD)" "su-iterative"
+sep
+for op in "${OPS[@]}"; do
+  m_no=$(mean_for_key "${op}|no")
+  m_ac=$(test_mean_aotcache "$op")
+  m_it=$(mean_for_key "${op}|iterative")
+  sd_no=$(stddev_for_key "${op}|no")
+  sd_ac=$(test_stddev_aotcache "$op")
+  sd_it=$(stddev_for_key "${op}|iterative")
+  su_ac=$(awk -v b="$m_no" -v a="$m_ac" 'BEGIN{if(a+0==0){print "n/a"}else{printf "%.2fx",b/a}}')
+  su_it=$(awk -v b="$m_no" -v a="$m_it" 'BEGIN{if(a+0==0){print "n/a"}else{printf "%.2fx",b/a}}')
+  printf "  %-16s | %18s | %20s %8s | %20s %8s\n" \
+    "$op" "${m_no}±${sd_no}" "${m_ac}±${sd_ac}" "$su_ac" "${m_it}±${sd_it}" "$su_it"
+done

--- a/commons-compress-experiment/workload-timed-iterative.sh
+++ b/commons-compress-experiment/workload-timed-iterative.sh
@@ -169,3 +169,43 @@ for op in "${OPS[@]}"; do
   printf "  %-16s | %18s | %20s %8s | %20s %8s\n" \
     "$op" "${m_no}±${sd_no}" "${m_ac}±${sd_ac}" "$su_ac" "${m_it}±${sd_it}" "$su_it"
 done
+
+# ─── class-load summary (same-workload aotcache for each op) ───────────────
+
+print_class_load_row() {
+  local mode="$1" op="$2"
+  local classload_log="$WORK_DIR/classload-${op}-${mode}.log"
+  case "$mode" in
+    no)
+      "$JAVA_BIN" -Xlog:class+load:file="$classload_log" \
+        -cp "$CP" "$MAIN" "$op" "$WORK_DIR"
+      ;;
+    aotcache)
+      "$JAVA_BIN" -XX:AOTCache="single-iterjdk-${op}.aot" \
+        -XX:+AOTClassLinking \
+        -Xlog:class+load:file="$classload_log" \
+        -cp "$CP" "$MAIN" "$op" "$WORK_DIR"
+      ;;
+    iterative)
+      "$JAVA_BIN" -XX:AOTCache="$ITERATIVE_AOT" \
+        -XX:+AOTClassLinking \
+        -Xlog:class+load:file="$classload_log" \
+        -cp "$CP" "$MAIN" "$op" "$WORK_DIR"
+      ;;
+  esac
+  printf "  %-16s | %-9s | %8s | %8s\n" \
+    "$op" "$mode" \
+    "$(awk '/source: file:/{count++} END{print count+0}' "$classload_log")" \
+    "$(awk '/source: shared object[s]? file/{count++} END{print count+0}' "$classload_log")"
+}
+
+echo
+log "Class-load source summary per workload (aotcache uses same-workload cache)"
+sep
+printf "  %-16s | %-9s | %8s | %8s\n" "Operation" "Mode" "file:" "shared"
+for op in "${OPS[@]}"; do
+  print_class_load_row "no" "$op"
+  print_class_load_row "aotcache" "$op"
+  print_class_load_row "iterative" "$op"
+  echo "--------------------------------"
+done

--- a/pdfbox-experiment/create-iterative-aot.sh
+++ b/pdfbox-experiment/create-iterative-aot.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Builds an AOT cache incrementally, one workload at a time, using the
+# one-step "-XX:AOTCache=<base> -XX:AOTCacheOutput=<next>" workflow added in
+# https://github.com/openjdk/jdk/pull/31344 ("iterative training for AOT
+# one-step workflow"). Each step loads the cache produced by the previous
+# step as its base and folds the new workload's classes into the output —
+# no AOTMode=record/create/merge needed, and no AOTMode=merge support is
+# required from the JDK (the build under test does not have it).
+#
+# Point JAVA_BIN at the JDK build that contains the PR before running, e.g.:
+#   JAVA_BIN=~/Desktop/tools/jdk/build/linux-x86_64-server-release-aot-re-training/images/jdk/bin/java \
+#     ./create-iterative-aot.sh
+set -euo pipefail
+
+log()  { echo -e "\033[1;32m[$(date '+%H:%M:%S')] $*\033[0m"; }
+fail() { echo -e "\033[1;31mERROR: $*\033[0m" >&2; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+JAVA_BIN="${JAVA_BIN:-java}"
+JAR="pdfbox/app/target/pdfbox-app-3.0.7.jar"
+MAIN="org.apache.pdfbox.tools.PDFBox"
+PDF="pdfbox/test.pdf"
+BASE="iterjdk"
+TMP="workload-tmp"
+
+log "Java binary: $JAVA_BIN"
+"$JAVA_BIN" -version
+
+[[ -f "$JAR" ]] || fail "$JAR not found — build pdfbox app first"
+[[ -f "$PDF" ]] || fail "$PDF not found"
+
+# Training order for the iterative cache.
+OPS=(export:text export:images render fromtext split merge decode overlay)
+
+mkdir -p "$TMP"
+
+op_args() {
+  local op="$1"
+  local -n _arr="$2"
+  case "$op" in
+    export:text)   _arr=(export:text   --input "$PDF" --output "$TMP/$BASE-text.txt") ;;
+    export:images) _arr=(export:images --input "$PDF") ;;
+    render)        _arr=(render        --input "$PDF") ;;
+    fromtext)      _arr=(fromtext      --input "$TMP/$BASE-text.txt"
+                           --output "$TMP/$BASE-from-text.pdf"
+                           -standardFont Times-Roman) ;;
+    split)         _arr=(split         --input "$PDF" -split 3 -outputPrefix "$TMP/split-$BASE") ;;
+    merge)         _arr=(merge         --input "$TMP/split-$BASE-1.pdf"
+                           --output "$TMP/merged-$BASE.pdf") ;;
+    decode)        _arr=(decode "$PDF" "$TMP/$BASE-decoded.pdf") ;;
+    overlay)       _arr=(overlay       -default "$PDF" --input "$PDF"
+                           --output "$TMP/$BASE-overlay.pdf") ;;
+    *) fail "Unknown op: $op" ;;
+  esac
+}
+
+log "Preparing prerequisite files…"
+"$JAVA_BIN" -cp "$JAR" "$MAIN" export:text --input "$PDF" --output "$TMP/$BASE-text.txt" >/dev/null 2>&1
+"$JAVA_BIN" -cp "$JAR" "$MAIN" split --input "$PDF" -split 3 -outputPrefix "$TMP/split-$BASE" >/dev/null 2>&1
+
+prev_aot=""
+for i in "${!OPS[@]}"; do
+  op="${OPS[$i]}"
+  safe="${op//:/-}"
+  step=$(( i + 1 ))
+  out_aot="iterative-step${step}-${safe}.aot"
+
+  if [ -f "$out_aot" ]; then
+    log "$out_aot already exists, skipping."
+    prev_aot="$out_aot"
+    continue
+  fi
+
+  base_args=()
+  if [ -n "$prev_aot" ]; then
+    base_args=(-XX:AOTCache="$prev_aot")
+    log "Step $step: folding '$op' into $prev_aot -> $out_aot"
+  else
+    log "Step $step: training '$op' from scratch -> $out_aot"
+  fi
+
+  args=()
+  op_args "$op" args
+  "$JAVA_BIN" \
+    "${base_args[@]}" \
+    -XX:AOTCacheOutput="$out_aot" \
+    -XX:+AOTClassLinking \
+    -cp "$JAR" "$MAIN" "${args[@]}"
+
+  test -f "$out_aot"
+  log "$out_aot created ($(du -sh "$out_aot" | cut -f1))"
+  prev_aot="$out_aot"
+done
+
+cp -f "$prev_aot" iterative.aot
+log "Final iterative cache: iterative.aot (copy of $prev_aot)"

--- a/pdfbox-experiment/create-single-aot-iterjdk.sh
+++ b/pdfbox-experiment/create-single-aot-iterjdk.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Same as create-single-aot.sh, but built with a configurable JAVA_BIN and
+# written to single-iterjdk-{op}.aot so caches built with the iterative-AOT
+# JDK build (PR 31344) don't collide with the single-{op}.aot files already
+# built with the stock JDK for the original experiment.
+#
+# Uses only the self-contained pdfbox-app jar (it already bundles jbig2 and
+# commons-io) instead of the pdfbox-deps/*/target/classes directories used
+# by create-single-aot.sh — CDS dump (record/create) rejects non-empty
+# directory classpath entries on this JDK build.
+set -euo pipefail
+
+log()  { echo -e "\033[1;32m[$(date '+%H:%M:%S')] $*\033[0m"; }
+fail() { echo -e "\033[1;31mERROR: $*\033[0m" >&2; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+JAVA_BIN="${JAVA_BIN:-java}"
+JAR="pdfbox/app/target/pdfbox-app-3.0.7.jar"
+MAIN="org.apache.pdfbox.tools.PDFBox"
+PDF="pdfbox/test.pdf"
+BASE="iterjdk"
+TMP="workload-tmp"
+OPS=(export:text export:images render fromtext split merge decode overlay)
+
+log "Java binary: $JAVA_BIN"
+"$JAVA_BIN" -version
+
+[[ -f "$JAR" ]] || fail "$JAR not found — build pdfbox app first"
+[[ -f "$PDF" ]] || fail "$PDF not found"
+
+mkdir -p "$TMP"
+
+# Builds the pdfbox CLI args for a given op into the named array variable.
+op_args() {
+  local op="$1"
+  local -n _arr="$2"
+  case "$op" in
+    export:text)   _arr=(export:text   --input "$PDF" --output "$TMP/$BASE-text.txt") ;;
+    export:images) _arr=(export:images --input "$PDF") ;;
+    render)        _arr=(render        --input "$PDF") ;;
+    fromtext)      _arr=(fromtext      --input "$TMP/$BASE-text.txt"
+                           --output "$TMP/$BASE-from-text.pdf"
+                           -standardFont Times-Roman) ;;
+    split)         _arr=(split         --input "$PDF" -split 3 -outputPrefix "$TMP/split-$BASE") ;;
+    merge)         _arr=(merge         --input "$TMP/split-$BASE-1.pdf"
+                           --output "$TMP/merged-$BASE.pdf") ;;
+    decode)        _arr=(decode "$PDF" "$TMP/$BASE-decoded.pdf") ;;
+    overlay)       _arr=(overlay       -default "$PDF" --input "$PDF"
+                           --output "$TMP/$BASE-overlay.pdf") ;;
+    *) fail "Unknown op: $op" ;;
+  esac
+}
+
+# Prepare prerequisite files needed by some ops during recording.
+log "Preparing prerequisite files…"
+"$JAVA_BIN" -cp "$JAR" "$MAIN" export:text --input "$PDF" --output "$TMP/$BASE-text.txt" >/dev/null 2>&1
+"$JAVA_BIN" -cp "$JAR" "$MAIN" split --input "$PDF" -split 3 -outputPrefix "$TMP/split-$BASE" >/dev/null 2>&1
+
+for op in "${OPS[@]}"; do
+  safe="${op//:/-}"
+  aot="single-iterjdk-${safe}.aot"
+  conf="single-iterjdk-${safe}.aotconf"
+  if [[ -f "$aot" ]]; then
+    log "$aot already exists, skipping."
+    continue
+  fi
+  log "Creating $aot (training op: $op)"
+  rm -f "$conf"
+
+  args=()
+  op_args "$op" args
+  "$JAVA_BIN" -XX:AOTMode=record -XX:AOTConfiguration="$conf" -XX:+AOTClassLinking \
+    -cp "$JAR" "$MAIN" "${args[@]}"
+
+  [[ -f "$conf" ]] || fail "AOT configuration file was not produced for op=$op"
+
+  "$JAVA_BIN" -XX:AOTMode=create \
+    -XX:AOTConfiguration="$conf" \
+    -XX:AOTCache="$aot" \
+    -XX:+AOTClassLinking \
+    -cp "$JAR"
+
+  [[ -f "$aot" ]] || fail "$aot was not created"
+  log "$aot created ($(du -sh "$aot" | cut -f1))"
+done

--- a/pdfbox-experiment/workload-timed-iterative.sh
+++ b/pdfbox-experiment/workload-timed-iterative.sh
@@ -2,10 +2,9 @@
 # Timing comparison for the iterative-AOT JDK build (PR 31344). Three modes:
 #   no        — no AOT cache
 #   aotcache  — single-iterjdk-{op}.aot cross-workload (cache trained on the
-#               other three ops, run on this one) — same shape as the
-#               original cross-workload test, rebuilt for this JDK build
+#               other ops, run on this one) — same shape as the original
+#               cross-workload test, rebuilt for this JDK build
 #   iterative — iterative.aot, built incrementally by create-iterative-aot.sh
-#               (gzip -> zip -> tar -> list-archives, each step folded into the next)
 #
 # Point JAVA_BIN at the JDK build under test, e.g.:
 #   JAVA_BIN=~/Desktop/tools/jdk/build/linux-x86_64-server-release-aot-re-training/images/jdk/bin/java \
@@ -20,34 +19,50 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
 JAVA_BIN="${JAVA_BIN:-java}"
-JAR="benchmark/target/original-benchmark-1.0-SNAPSHOT.jar"
-DEPS_DIR="single-aot-deps"
-# single-iterjdk-{op}.aot and iterative.aot are both recorded against JARs
-# (CDS dump rejects non-empty directory classpath entries) — use the
-# matching JAR-based classpath for all run modes here.
-CP="$JAR:\
-$DEPS_DIR/commons-compress-1.28.0.jar:\
-$DEPS_DIR/commons-lang3-3.20.0.jar:\
-$DEPS_DIR/commons-codec-1.21.0.jar:\
-$DEPS_DIR/commons-io-2.20.0.jar"
-MAIN="dev.compressexp.Main"
-WORK_DIR="workload-tmp"
+JAR="pdfbox/app/target/pdfbox-app-3.0.7.jar"
+MAIN="org.apache.pdfbox.tools.PDFBox"
+PDF="pdfbox/test.pdf"
+BASE="iterjdk"
+TMP="workload-tmp"
 ITERATIVE_AOT="iterative.aot"
 RUNS="${RUNS:-30}"
-OPS=("gzip-roundtrip" "zip-roundtrip" "tar-roundtrip" "list-archives")
+OPS=(export:text export:images render fromtext split merge decode overlay)
 
-[[ -f "$JAR" ]] || fail "$JAR not found — run: cd benchmark && mvn package -DskipTests"
+[[ -f "$JAR" ]] || fail "$JAR not found — build pdfbox first"
+[[ -f "$PDF" ]] || fail "$PDF not found"
 [[ -f "$ITERATIVE_AOT" ]] || fail "$ITERATIVE_AOT not found — run create-iterative-aot.sh first"
 for _op in "${OPS[@]}"; do
-  [[ -f "single-iterjdk-${_op}.aot" ]] || fail "single-iterjdk-${_op}.aot not found — run create-single-aot-iterjdk.sh first"
+  [[ -f "single-iterjdk-${_op//:/-}.aot" ]] || fail "single-iterjdk-${_op//:/-}.aot not found — run create-single-aot-iterjdk.sh first"
 done
 
-mkdir -p "$WORK_DIR"
+mkdir -p "$TMP"
 
 log "Java binary under test: $JAVA_BIN"
 "$JAVA_BIN" -version
 
-"$JAVA_BIN" -cp "$CP" "$MAIN" prepare "$WORK_DIR" >/dev/null
+op_args() {
+  local op="$1"
+  local -n _arr="$2"
+  case "$op" in
+    export:text)   _arr=(export:text   --input "$PDF" --output "$TMP/$BASE-text.txt") ;;
+    export:images) _arr=(export:images --input "$PDF") ;;
+    render)        _arr=(render        --input "$PDF") ;;
+    fromtext)      _arr=(fromtext      --input "$TMP/$BASE-text.txt"
+                           --output "$TMP/$BASE-from-text.pdf"
+                           -standardFont Times-Roman) ;;
+    split)         _arr=(split         --input "$PDF" -split 3 -outputPrefix "$TMP/split-$BASE") ;;
+    merge)         _arr=(merge         --input "$TMP/split-$BASE-1.pdf"
+                           --output "$TMP/merged-$BASE.pdf") ;;
+    decode)        _arr=(decode "$PDF" "$TMP/$BASE-decoded.pdf") ;;
+    overlay)       _arr=(overlay       -default "$PDF" --input "$PDF"
+                           --output "$TMP/$BASE-overlay.pdf") ;;
+    *) fail "Unknown op: $op" ;;
+  esac
+}
+
+log "Preparing prerequisite files for workload…"
+"$JAVA_BIN" -cp "$JAR" "$MAIN" export:text --input "$PDF" --output "$TMP/$BASE-text.txt" >/dev/null 2>&1
+"$JAVA_BIN" -cp "$JAR" "$MAIN" split --input "$PDF" -split 3 -outputPrefix "$TMP/split-$BASE" >/dev/null 2>&1
 
 ms() { date +%s%N | awk '{printf "%.1f", $1/1000000}'; }
 
@@ -74,27 +89,31 @@ stddev_for_key() {
 
 run_no() {
   local op="$1"
-  "$JAVA_BIN" -cp "$CP" "$MAIN" "$op" "$WORK_DIR"
+  local -a args; op_args "$op" args
+  "$JAVA_BIN" -cp "$JAR" "$MAIN" "${args[@]}"
 }
 
 # train_op determines which single-iterjdk-{op}.aot to load; test_op is the workload run.
 run_aotcache_cross() {
   local train_op="$1" test_op="$2"
-  "$JAVA_BIN" -XX:AOTCache="single-iterjdk-${train_op}.aot" -XX:+AOTClassLinking \
-    -cp "$CP" "$MAIN" "$test_op" "$WORK_DIR"
+  local -a args; op_args "$test_op" args
+  "$JAVA_BIN" -XX:AOTCache="single-iterjdk-${train_op//:/-}.aot" -XX:+AOTClassLinking \
+    -cp "$JAR" "$MAIN" "${args[@]}"
 }
 
 run_iterative() {
   local op="$1"
+  local -a args; op_args "$op" args
   "$JAVA_BIN" -XX:AOTCache="$ITERATIVE_AOT" -XX:+AOTClassLinking \
-    -cp "$CP" "$MAIN" "$op" "$WORK_DIR"
+    -cp "$JAR" "$MAIN" "${args[@]}"
 }
 
 measure_ms() {
   local label_op="$1" label_mode="$2"
   shift 2
   local file_label_op="${label_op//>/-to-}"
-  local err_file="$WORK_DIR/${RUN_IDX:-0}-${file_label_op}-${label_mode}.stderr.log"
+  file_label_op="${file_label_op//:/-}"
+  local err_file="$TMP/${RUN_IDX:-0}-${file_label_op}-${label_mode}.stderr.log"
   local start end rc
   start=$(ms)
   "$@" >/dev/null 2>"$err_file"
@@ -133,7 +152,7 @@ test_stddev_aotcache() {
     END { if (n < 2) { print "n/a" } else { printf "%.1f", sqrt((sumsq - sum*sum/n) / (n-1)) } }'
 }
 
-log "Running Commons Compress iterative-AOT workload RUNS=$RUNS"
+log "Running PDFBox iterative-AOT workload RUNS=$RUNS"
 for RUN_IDX in $(seq 1 "$RUNS"); do
   printf "  run %2d/%d\n" "$RUN_IDX" "$RUNS"
   # no and iterative: one pass over all ops
@@ -174,23 +193,25 @@ done
 
 print_class_load_row() {
   local mode="$1" op="$2"
-  local classload_log="$WORK_DIR/classload-${op}-${mode}.log"
+  local safe="${op//:/-}"
+  local classload_log="$TMP/classload-${safe}-${mode}.log"
+  local -a args; op_args "$op" args
   case "$mode" in
     no)
       "$JAVA_BIN" -Xlog:class+load:file="$classload_log" \
-        -cp "$CP" "$MAIN" "$op" "$WORK_DIR"
+        -cp "$JAR" "$MAIN" "${args[@]}" >/dev/null 2>&1
       ;;
     aotcache)
-      "$JAVA_BIN" -XX:AOTCache="single-iterjdk-${op}.aot" \
+      "$JAVA_BIN" -XX:AOTCache="single-iterjdk-${safe}.aot" \
         -XX:+AOTClassLinking \
         -Xlog:class+load:file="$classload_log" \
-        -cp "$CP" "$MAIN" "$op" "$WORK_DIR"
+        -cp "$JAR" "$MAIN" "${args[@]}" >/dev/null 2>&1
       ;;
     iterative)
       "$JAVA_BIN" -XX:AOTCache="$ITERATIVE_AOT" \
         -XX:+AOTClassLinking \
         -Xlog:class+load:file="$classload_log" \
-        -cp "$CP" "$MAIN" "$op" "$WORK_DIR"
+        -cp "$JAR" "$MAIN" "${args[@]}" >/dev/null 2>&1
       ;;
   esac
   printf "  %-16s | %-9s | %8s | %8s\n" \
@@ -218,7 +239,8 @@ sep
 printf "  %-40s | %10s\n" "Cache" "Size"
 sep
 for op in "${OPS[@]}"; do
-  printf "  %-40s | %10s\n" "single-iterjdk-${op}.aot" "$(du -h "single-iterjdk-${op}.aot" | awk '{print $1}')"
+  safe="${op//:/-}"
+  printf "  %-40s | %10s\n" "single-iterjdk-${safe}.aot" "$(du -h "single-iterjdk-${safe}.aot" | awk '{print $1}')"
 done
 for f in iterative-step*.aot; do
   [[ -f "$f" ]] || continue


### PR DESCRIPTION
Evaluates the supply-chain-aotcache JDK build's one-step iterative training flow (load existing cache via -XX:AOTCache=, fold in a new workload, write the combined result via -XX:AOTCacheOutput=) against the no-AOT and cross-workload single.aot baselines, without requiring AOTMode=merge support.

The goal is to benchmark: https://github.com/openjdk/jdk/pull/31344