### PR TITLE
Add tree-merge profile to batik commons-io

### DIFF
--- a/.github/workflows/batik-aot-cache.yml
+++ b/.github/workflows/batik-aot-cache.yml
@@ -68,12 +68,12 @@ jobs:
           mvn clean test -Ptree-merge -q
           test -f cache.aot
 
-      - name: Build commons-io cache (mvn test)
+      - name: Build commons-io cache (tree-merge)
         working-directory: batik-experiment/batik-deps/commons-io
         run: |
           set -euo pipefail
           find . -name "*.aot" -type f -delete
-          mvn clean test -q
+          mvn clean test -Ptree-merge -Drat.skip -q
           test -f cache.aot
 
       # ── workload caches ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
commons-io was the only test-suite module in the batik experiment without a proper `tree-merge` profile — its AOT cache was being generated unconditionally on every `mvn test` run via a hardcoded `<argLine>` in the default surefire configuration.

## Changes
- **`batik-experiment/batik-deps/commons-io/pom.xml`**: removed the AOT `<argLine>` from the default surefire `<configuration>` block; added a `tree-merge` profile that sets `-Xlog:aot+map=trace,aot+map+oops=trace,aot=warning:file=aot.map:none:filesize=0 -XX:AOTCacheOutput=${project.basedir}/cache.aot` and `<testFailureIgnore>true</testFailureIgnore>`, matching the pattern used by `batik-test-old` and `xmlgraphics-commons`
- **`.github/workflows/batik-aot-cache.yml`**: updated the commons-io cache-build step from `mvn clean test -q` to `mvn clean test -Ptree-merge -Drat.skip -q`

## Testing
The `batik-aot-cache` CI workflow will exercise this change — the commons-io step should produce `cache.aot` and `aot.map` under `batik-experiment/batik-deps/commons-io/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)