### PR TITLE
Add checkstyle AOT cache experiment

### DIFF
--- a/.github/workflows/checkstyle-aot-cache.yml
+++ b/.github/workflows/checkstyle-aot-cache.yml
@@ -1,0 +1,162 @@
+name: Checkstyle Distributed AOT Cache
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      single_aot_jdk:
+        description: 'JDK version used for single.aot and the no-AOT baseline'
+        required: false
+        default: '24'
+        type: choice
+        options:
+          - '25'
+          - '24'
+
+jobs:
+  tree-combine:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          submodules: true
+
+      - name: Download custom JDK
+        uses: ./.github/actions/download-custom-jdk
+
+      - name: Set up custom JDK
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: jdkfile
+          java-version: '25'
+          jdkFile: jdk-custom.tar.gz
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-checkstyle-${{ hashFiles('checkstyle-experiment/**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-checkstyle-
+            ${{ runner.os }}-maven-
+
+      # ── tree-merge cache ───────────────────────────────────────────────────
+
+      - name: Build checkstyle cache (tree-merge)
+        working-directory: checkstyle-experiment/checkstyle
+        run: |
+          set -euo pipefail
+          find . -name "cache.aot" -o -name "aot.map" | xargs rm -f 2>/dev/null || true
+          mvn clean test -P tree-merge -Dmaven.test.failure.ignore=true -q
+          test -f cache.aot
+
+      # ── benchmark fat JAR ──────────────────────────────────────────────────
+
+      - name: Build benchmark fat JAR
+        working-directory: checkstyle-experiment/benchmark
+        run: mvn package -DskipTests -q
+
+      # ── single.aot (Temurin — standard JDK for no-AOT baseline) ──────────
+
+      - name: Set up JDK ${{ inputs.single_aot_jdk || '24' }} (no-AOT baseline and single.aot)
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: temurin
+          java-version: ${{ inputs.single_aot_jdk || '24' }}
+
+      - name: Capture Temurin JDK path
+        run: echo "TEMURIN_JAVA_HOME=$JAVA_HOME" >> "$GITHUB_ENV"
+
+      - name: Create single.aot per workload (JDK ${{ inputs.single_aot_jdk || '24' }})
+        working-directory: checkstyle-experiment
+        run: |
+          set -euo pipefail
+          chmod +x create-single-aot.sh
+          ./create-single-aot.sh
+          for op in sun google javadoc naming sizes; do
+            test -f "single-${op}.aot"
+          done
+
+      # ── tree.aot (custom JDK — has AOTMergeInputs) ────────────────────────
+
+      - name: Re-enable custom JDK
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: jdkfile
+          java-version: '25'
+          jdkFile: jdk-custom.tar.gz
+
+      - name: Create tree.aot (orchestrate-combine.sh)
+        working-directory: checkstyle-experiment
+        run: |
+          set -euo pipefail
+          chmod +x orchestrate-combine.sh
+          combine_out=$(./orchestrate-combine.sh 2>&1) || { echo "$combine_out"; exit 1; }
+          echo "$combine_out"
+          combine_out_clean=$(echo "$combine_out" | sed 's/\x1B\[[0-9;]*m//g')
+          tree_size=$(du -h tree.aot | awk '{print $1}')
+          {
+            echo "## tree.aot creation (orchestrate-combine)"
+            echo
+            echo "- tree.aot: ${tree_size}"
+            echo
+            echo '```'
+            echo "$combine_out_clean"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          test -f tree.aot
+
+      # ── timed workload ─────────────────────────────────────────────────────
+
+      - name: Run timed workload
+        working-directory: checkstyle-experiment
+        run: |
+          set -euo pipefail
+          chmod +x workload-timed.sh
+          wl_out=$(JAVA_NO_BIN="$TEMURIN_JAVA_HOME/bin/java" \
+                   JAVA_SINGLE_BIN="$TEMURIN_JAVA_HOME/bin/java" \
+                   JAVA_TREE_BIN="$JAVA_HOME/bin/java" \
+                   ./workload-timed.sh 2>&1) || { echo "$wl_out"; exit 1; }
+          echo "$wl_out"
+          wl_out_clean=$(echo "$wl_out" | sed 's/\x1B\[[0-9;]*m//g')
+          single_size=$(du -ch single-*.aot | tail -1 | awk '{print $1}')
+          tree_size=$(du -h tree.aot | awk '{print $1}')
+          {
+            echo "## Timed workload results (no-AOT vs single vs tree)"
+            echo
+            echo "- single-*.aot total: ${single_size}"
+            echo "- tree.aot: ${tree_size}"
+            echo
+            echo '```'
+            echo "$wl_out_clean"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Append LaTeX table rows to summary
+        working-directory: checkstyle-experiment
+        run: |
+          {
+            echo "## LaTeX table rows (single=AOTCache, tree=TreeCache)"
+            echo
+            echo '```latex'
+            cat workload-tmp/latex-rows.tex
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # ── upload ─────────────────────────────────────────────────────────────
+
+      - name: Upload checkstyle workload artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: checkstyle-tree-artifacts
+          path: |
+            checkstyle-experiment/workload-tmp/
+            checkstyle-experiment/aot.map
+            checkstyle-experiment/checkstyle/cache.aot
+            checkstyle-experiment/checkstyle/aot.map
+            checkstyle-experiment/single-*.aot
+            checkstyle-experiment/tree.aot
+          if-no-files-found: error

--- a/.gitmodules
+++ b/.gitmodules
@@ -109,3 +109,7 @@
 	path = opennlp-experiment/opennlp-deps/morfologik
 	url = git@github.com:algomaster99/morfologik-stemming.git
 	branch = aot-profiles
+[submodule "checkstyle-experiment/checkstyle"]
+	path = checkstyle-experiment/checkstyle
+	url = git@github.com:algomaster99/checkstyle.git
+	branch = aotcache-setup

--- a/checkstyle-experiment/benchmark/pom.xml
+++ b/checkstyle-experiment/benchmark/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>dev.checkstyleexp</groupId>
+  <artifactId>benchmark</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <!--
+    Fat JAR (shade) — benchmark code + all transitive deps bundled.
+    checkstyle classes are excluded from the shade; at runtime the classpath is:
+      benchmark-fat.jar : checkstyle/target/classes
+    This keeps the classpath fingerprint consistent with the tree-merge AOT recording.
+  -->
+  <properties>
+    <checkstyle.version>13.6.0</checkstyle.version>
+    <maven.compiler.release>11</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.puppycrawl.tools</groupId>
+      <artifactId>checkstyle</artifactId>
+      <version>${checkstyle.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.6.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals><goal>shade</goal></goals>
+            <configuration>
+              <finalName>benchmark-fat</finalName>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <filters>
+                <!-- Exclude checkstyle classes — provided via target/classes at runtime -->
+                <filter>
+                  <artifact>com.puppycrawl.tools:checkstyle</artifact>
+                  <excludes><exclude>**</exclude></excludes>
+                </filter>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                    <exclude>module-info.class</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>dev.checkstyleexp.Main</mainClass>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/checkstyle-experiment/benchmark/src/main/java/dev/checkstyleexp/Main.java
+++ b/checkstyle-experiment/benchmark/src/main/java/dev/checkstyleexp/Main.java
@@ -1,0 +1,46 @@
+package dev.checkstyleexp;
+
+import com.puppycrawl.tools.checkstyle.Checker;
+import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
+import com.puppycrawl.tools.checkstyle.PropertiesExpander;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+public class Main {
+
+    public static void main(String[] args) throws Exception {
+        if (args.length < 3) {
+            System.err.println("Usage: Main <workload> <configs-dir> <sources-dir>");
+            System.exit(1);
+        }
+        String workload = args[0];
+        String configsDir = args[1];
+        String sourcesDir = args[2];
+
+        String configFile = configsDir + "/" + workload + ".xml";
+
+        Properties props = new Properties();
+        props.setProperty("basedir", new File(sourcesDir).getAbsolutePath());
+
+        Configuration config = ConfigurationLoader.loadConfiguration(
+            configFile, new PropertiesExpander(props));
+
+        Checker checker = new Checker();
+        checker.setModuleClassLoader(Main.class.getClassLoader());
+        checker.configure(config);
+
+        List<File> files = Files.walk(Path.of(sourcesDir))
+            .filter(p -> p.toString().endsWith(".java"))
+            .map(Path::toFile)
+            .collect(Collectors.toList());
+
+        checker.process(files);
+        checker.destroy();
+    }
+}

--- a/checkstyle-experiment/configs/google.xml
+++ b/checkstyle-experiment/configs/google.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <property name="severity" value="warning"/>
+  <module name="LineLength">
+    <property name="max" value="100"/>
+  </module>
+  <module name="TreeWalker">
+    <module name="Indentation">
+      <property name="basicOffset" value="2"/>
+      <property name="braceAdjustment" value="0"/>
+      <property name="caseIndent" value="2"/>
+      <property name="throwsIndent" value="4"/>
+      <property name="lineWrappingIndentation" value="4"/>
+      <property name="arrayInitIndent" value="2"/>
+    </module>
+    <module name="OneTopLevelClass"/>
+    <module name="NoLineWrap"/>
+    <module name="EmptyBlock">
+      <property name="option" value="TEXT"/>
+      <property name="tokens" value="LITERAL_TRY,LITERAL_FINALLY,LITERAL_IF,LITERAL_ELSE,LITERAL_SWITCH"/>
+    </module>
+    <module name="MultipleVariableDeclarations"/>
+    <module name="NoFinalizer"/>
+    <module name="OverloadMethodsDeclarationOrder"/>
+    <module name="VariableDeclarationUsageDistance"/>
+    <module name="AvoidEscapedUnicodeCharacters">
+      <property name="allowEscapesForControlCharacters" value="true"/>
+      <property name="allowByTailComment" value="true"/>
+      <property name="allowNonPrintableEscapes" value="true"/>
+    </module>
+  </module>
+</module>

--- a/checkstyle-experiment/configs/javadoc.xml
+++ b/checkstyle-experiment/configs/javadoc.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <property name="severity" value="warning"/>
+  <module name="TreeWalker">
+    <module name="JavadocMethod">
+      <property name="accessModifiers" value="public"/>
+    </module>
+    <module name="JavadocType"/>
+    <module name="JavadocVariable">
+      <property name="scope" value="public"/>
+    </module>
+    <module name="MissingJavadocMethod">
+      <property name="scope" value="public"/>
+    </module>
+    <module name="MissingJavadocType">
+      <property name="scope" value="public"/>
+    </module>
+    <module name="InvalidJavadocPosition"/>
+    <module name="JavadocTagContinuationIndentation"/>
+    <module name="NonEmptyAtclauseDescription"/>
+    <module name="AtclauseOrder">
+      <property name="tagOrder" value="@param,@return,@throws,@deprecated"/>
+    </module>
+  </module>
+</module>

--- a/checkstyle-experiment/configs/naming.xml
+++ b/checkstyle-experiment/configs/naming.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <property name="severity" value="warning"/>
+  <module name="TreeWalker">
+    <module name="ConstantName"/>
+    <module name="LocalFinalVariableName"/>
+    <module name="LocalVariableName"/>
+    <module name="MemberName"/>
+    <module name="MethodName"/>
+    <module name="PackageName"/>
+    <module name="ParameterName"/>
+    <module name="StaticVariableName"/>
+    <module name="TypeName"/>
+    <module name="AbbreviationAsWordInName">
+      <property name="allowedAbbreviationLength" value="1"/>
+    </module>
+    <module name="CatchParameterName"/>
+    <module name="ClassTypeParameterName"/>
+    <module name="MethodTypeParameterName"/>
+    <module name="InterfaceTypeParameterName"/>
+    <module name="LambdaParameterName"/>
+  </module>
+</module>

--- a/checkstyle-experiment/configs/sizes.xml
+++ b/checkstyle-experiment/configs/sizes.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <property name="severity" value="warning"/>
+  <module name="FileLength">
+    <property name="max" value="2000"/>
+  </module>
+  <module name="LineLength">
+    <property name="max" value="120"/>
+  </module>
+  <module name="TreeWalker">
+    <module name="MethodLength">
+      <property name="max" value="150"/>
+    </module>
+    <module name="ParameterNumber">
+      <property name="max" value="7"/>
+    </module>
+    <module name="AnonInnerLength">
+      <property name="max" value="20"/>
+    </module>
+    <module name="OuterTypeNumber"/>
+    <module name="MethodCount">
+      <property name="maxTotal" value="30"/>
+    </module>
+    <module name="ExecutableStatementCount">
+      <property name="max" value="30"/>
+    </module>
+  </module>
+</module>

--- a/checkstyle-experiment/configs/sun.xml
+++ b/checkstyle-experiment/configs/sun.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <property name="severity" value="warning"/>
+  <module name="FileTabCharacter"/>
+  <module name="NewlineAtEndOfFile"/>
+  <module name="TreeWalker">
+    <module name="WhitespaceAfter"/>
+    <module name="WhitespaceAround"/>
+    <module name="NoWhitespaceBefore"/>
+    <module name="EmptyLineSeparator">
+      <property name="allowNoEmptyLineBetweenFields" value="true"/>
+    </module>
+    <module name="LeftCurly"/>
+    <module name="RightCurly"/>
+    <module name="NeedBraces"/>
+    <module name="OperatorWrap"/>
+    <module name="ParenPad"/>
+    <module name="TypecastParenPad"/>
+    <module name="VisibilityModifier"/>
+    <module name="FinalClass"/>
+    <module name="InterfaceIsType"/>
+    <module name="HideUtilityClassConstructor"/>
+  </module>
+</module>

--- a/checkstyle-experiment/create-single-aot.sh
+++ b/checkstyle-experiment/create-single-aot.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Creates one single-{op}.aot per workload for the cross-workload experiment.
+set -euo pipefail
+
+log()  { echo -e "\033[1;32m[$(date '+%H:%M:%S')] $*\033[0m"; }
+fail() { echo -e "\033[1;31mERROR: $*\033[0m" >&2; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+BENCH_JAR="benchmark/target/benchmark-fat.jar"
+CHECKSTYLE_CORE="checkstyle/target/classes"
+CP="$BENCH_JAR:$CHECKSTYLE_CORE"
+MAIN="dev.checkstyleexp.Main"
+CONFIGS_DIR="$SCRIPT_DIR/configs"
+SOURCES_DIR="$SCRIPT_DIR/sources"
+OPS=(sun google javadoc naming sizes)
+JAVA_BIN="${JAVA_BIN:-java}"
+
+[[ -f "$BENCH_JAR" ]] || fail "$BENCH_JAR not found — run: cd benchmark && mvn package -DskipTests"
+[[ -d "$CHECKSTYLE_CORE" ]] || fail "$CHECKSTYLE_CORE not found — run: cd checkstyle && mvn compile -DskipTests"
+
+for op in "${OPS[@]}"; do
+  aot="single-${op}.aot"
+  conf="single-${op}.aotconf"
+  if [[ -f "$aot" ]]; then
+    log "$aot already exists, skipping."
+    continue
+  fi
+  log "Creating $aot (training op: $op)"
+  rm -f "$conf"
+  "$JAVA_BIN" -XX:AOTMode=record -XX:AOTConfiguration="$conf" \
+    -XX:+AOTClassLinking \
+    -cp "$CP" "$MAIN" "$op" "$CONFIGS_DIR" "$SOURCES_DIR"
+  [[ -f "$conf" ]] || fail "AOT configuration file was not produced for op=$op"
+  "$JAVA_BIN" -XX:AOTMode=create \
+    -XX:AOTConfiguration="$conf" \
+    -XX:AOTCache="$aot" \
+    -XX:+AOTClassLinking \
+    -cp "$CP"
+  [[ -f "$aot" ]] || fail "$aot was not created"
+  log "$aot created ($(du -sh "$aot" | cut -f1))"
+done

--- a/checkstyle-experiment/orchestrate-combine.sh
+++ b/checkstyle-experiment/orchestrate-combine.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+
+log()  { echo -e "\033[1;32m[$(date '+%H:%M:%S')] $*\033[0m"; }
+fail() { echo -e "\033[1;31mERROR: $*\033[0m" >&2; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Cache recorded by: cd checkstyle && mvn clean test -P tree-merge -Dmaven.test.failure.ignore=true
+CACHE_PATHS=(
+  "checkstyle/cache.aot"
+)
+
+BENCH_JAR="benchmark/target/benchmark-fat.jar"
+CHECKSTYLE_CORE="checkstyle/target/classes"
+CP="$BENCH_JAR:$CHECKSTYLE_CORE"
+OUTPUT_AOT="tree.aot"
+
+[[ -f "$BENCH_JAR" ]] || fail "$BENCH_JAR not found — run: cd benchmark && mvn package -DskipTests"
+[[ -d "$CHECKSTYLE_CORE" ]] || fail "$CHECKSTYLE_CORE not found — build checkstyle first"
+for path in "${CACHE_PATHS[@]}"; do
+  [[ -f "$path" ]] || fail "Missing cache: $path"
+done
+
+BASE_AOT="${CACHE_PATHS[0]}"
+MERGE_INPUTS="$(IFS=:; echo "${CACHE_PATHS[*]}")"
+
+rm -f "$OUTPUT_AOT"
+
+log "Merging ${#CACHE_PATHS[@]} cache(s) → $OUTPUT_AOT"
+java -Xlog:aot=info \
+  -Xlog:aot+map=trace,aot+map+oops=trace,aot=warning:file=aot.map:none:filesize=0 \
+  -XX:AOTMode=merge \
+  -XX:AOTCache="$BASE_AOT" \
+  -XX:AOTMergeInputs="$MERGE_INPUTS" \
+  -XX:AOTCacheOutput="$OUTPUT_AOT" \
+  -cp "$CP" \
+  -version
+
+[[ -f "$OUTPUT_AOT" ]] || fail "tree.aot was not created"
+log "$OUTPUT_AOT created ($(du -sh "$OUTPUT_AOT" | cut -f1))"

--- a/checkstyle-experiment/sources/AnotherClass.java
+++ b/checkstyle-experiment/sources/AnotherClass.java
@@ -1,0 +1,118 @@
+package com.example;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * A second sample class with full Javadoc for contrast with SampleClass.
+ */
+public class AnotherClass {
+
+    /** Default name used when no name is provided. */
+    public static final String DEFAULT_NAME = "default";
+
+    /** Maximum allowed name length. */
+    public static final int MAX_NAME_LENGTH = 255;
+
+    private final String name;
+    private final int priority;
+
+    /**
+     * Constructs a new AnotherClass.
+     *
+     * @param name     the name, must not be null
+     * @param priority the priority level (higher is more important)
+     */
+    public AnotherClass(String name, int priority) {
+        if (name == null || name.length() > MAX_NAME_LENGTH) {
+            throw new IllegalArgumentException("Invalid name");
+        }
+        this.name = name;
+        this.priority = priority;
+    }
+
+    /**
+     * Returns the name.
+     *
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the priority.
+     *
+     * @return the priority level
+     */
+    public int getPriority() {
+        return priority;
+    }
+
+    /**
+     * Compares priority with another instance.
+     *
+     * @param other the other instance to compare
+     * @return true if this instance has higher priority
+     */
+    public boolean isHigherPriorityThan(AnotherClass other) {
+        return this.priority > other.priority;
+    }
+
+    /**
+     * Returns an optional wrapping this instance if name is non-empty.
+     *
+     * @return optional containing this, or empty
+     */
+    public Optional<AnotherClass> asOptional() {
+        return name.isEmpty() ? Optional.empty() : Optional.of(this);
+    }
+
+    /**
+     * Returns a singleton list containing only this instance.
+     *
+     * @return immutable singleton list
+     */
+    public List<AnotherClass> asSingletonList() {
+        return Collections.singletonList(this);
+    }
+
+    /**
+     * Immutable value type for name/priority pairs.
+     */
+    public static final class Entry {
+
+        private final String key;
+        private final int value;
+
+        /**
+         * Constructs an Entry.
+         *
+         * @param key   the key
+         * @param value the value
+         */
+        public Entry(String key, int value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        /**
+         * Returns the key.
+         *
+         * @return the key
+         */
+        public String getKey() {
+            return key;
+        }
+
+        /**
+         * Returns the value.
+         *
+         * @return the value
+         */
+        public int getValue() {
+            return value;
+        }
+    }
+}

--- a/checkstyle-experiment/sources/SampleClass.java
+++ b/checkstyle-experiment/sources/SampleClass.java
@@ -1,0 +1,80 @@
+package com.example;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class SampleClass {
+
+    private static final int MAX_VALUE = 100;
+    private static final String DEFAULT_PREFIX = "item";
+
+    private int counter;
+    private String label;
+
+    public SampleClass(int counter, String label) {
+        this.counter = counter;
+        this.label = label;
+    }
+
+    public int getCounter() {
+        return counter;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public int computeResult(int inputParam, int anotherParam) {
+        int localVar = inputParam + anotherParam;
+        if (localVar > MAX_VALUE) {
+            return MAX_VALUE;
+        }
+        return localVar;
+    }
+
+    public List<String> buildItems(String prefix, int count, boolean includeEmpty, String suffix, int limit) {
+        List<String> result = new ArrayList<>();
+        for (int i = 0; i < count && i < limit; i++) {
+            String item = prefix + i + suffix;
+            if (includeEmpty || !item.isEmpty()) {
+                result.add(item);
+            }
+        }
+        return result;
+    }
+
+    public void processEntries(Map<String, List<Integer>> data) {
+        for (Map.Entry<String, List<Integer>> entry : data.entrySet()) {
+            String key = entry.getKey();
+            List<Integer> values = entry.getValue();
+            for (int val : values) {
+                if (val > 0) {
+                    if (val > 50) {
+                        System.out.println(key + ": " + val);
+                    }
+                }
+            }
+        }
+    }
+
+    public static class Builder {
+
+        private int counter = 0;
+        private String label = DEFAULT_PREFIX;
+
+        public Builder counter(int counter) {
+            this.counter = counter;
+            return this;
+        }
+
+        public Builder label(String label) {
+            this.label = label;
+            return this;
+        }
+
+        public SampleClass build() {
+            return new SampleClass(counter, label);
+        }
+    }
+}

--- a/checkstyle-experiment/workload-timed.sh
+++ b/checkstyle-experiment/workload-timed.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+set -euo pipefail
+
+log()  { echo -e "\033[1;32m[$(date '+%H:%M:%S')] $*\033[0m"; }
+sep()  { echo -e "\033[0;90m  $(printf '─%.0s' {1..60})\033[0m"; }
+fail() { echo -e "\033[1;31mERROR: $*\033[0m" >&2; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+BENCH_JAR="benchmark/target/benchmark-fat.jar"
+CHECKSTYLE_CORE="checkstyle/target/classes"
+CP="$BENCH_JAR:$CHECKSTYLE_CORE"
+MAIN="dev.checkstyleexp.Main"
+CONFIGS_DIR="$SCRIPT_DIR/configs"
+SOURCES_DIR="$SCRIPT_DIR/sources"
+TREE_AOT="tree.aot"
+RUNS="${RUNS:-30}"
+JAVA_NO_BIN="${JAVA_NO_BIN:-java}"
+JAVA_SINGLE_BIN="${JAVA_SINGLE_BIN:-java}"
+JAVA_TREE_BIN="${JAVA_TREE_BIN:-java}"
+OPS=(sun google javadoc naming sizes)
+
+[[ -f "$BENCH_JAR" ]] || fail "$BENCH_JAR not found — run: cd benchmark && mvn package -DskipTests"
+[[ -d "$CHECKSTYLE_CORE" ]] || fail "$CHECKSTYLE_CORE not found — build checkstyle first"
+for op in "${OPS[@]}"; do
+  [[ -f "single-${op}.aot" ]] || fail "single-${op}.aot not found — run ./create-single-aot.sh"
+done
+[[ -f "$TREE_AOT" ]] || fail "tree.aot not found — run ./orchestrate-combine.sh first"
+
+log "Java version: $("$JAVA_NO_BIN" -version 2>&1 | head -1)"
+
+ms() { date +%s%N | awk '{printf "%.1f", $1/1000000}'; }
+
+declare -A minv maxv cnt samples
+
+update_stats() {
+  local key="$1" t="$2"
+  cnt[$key]=$(( ${cnt[$key]:-0} + 1 ))
+  samples[$key]="${samples[$key]:-} $t"
+  if [[ -z "${minv[$key]:-}" ]] || awk "BEGIN{exit !(${t}<${minv[$key]})}"; then minv[$key]="$t"; fi
+  if [[ -z "${maxv[$key]:-}" ]] || awk "BEGIN{exit !(${t}>${maxv[$key]})}"; then maxv[$key]="$t"; fi
+}
+
+mean_for_key() {
+  printf "%s\n" ${samples[$1]:-} | awk '{s+=$1;n++}END{if(n==0){print "n/a"}else{printf "%.1f",s/n}}'
+}
+
+stddev_for_key() {
+  printf "%s\n" ${samples[$1]:-} | awk '{s+=$1;q+=$1*$1;n++}END{if(n<2){print "n/a"}else{printf "%.1f",sqrt((q-s*s/n)/(n-1))}}'
+}
+
+run_no() {
+  "$JAVA_NO_BIN" -cp "$CP" "$MAIN" "$1" "$CONFIGS_DIR" "$SOURCES_DIR"
+}
+
+run_single() {
+  "$JAVA_SINGLE_BIN" -XX:AOTCache="single-${1}.aot" -XX:+AOTClassLinking \
+    -cp "$CP" "$MAIN" "$2" "$CONFIGS_DIR" "$SOURCES_DIR"
+}
+
+run_tree() {
+  "$JAVA_TREE_BIN" -XX:AOTCache="$TREE_AOT" -XX:+AOTClassLinking \
+    -cp "$CP" "$MAIN" "$1" "$CONFIGS_DIR" "$SOURCES_DIR"
+}
+
+measure_ms() {
+  local label="$1" mode="$2"; shift 2
+  local err_file="workload-tmp/${RUN_IDX:-0}-${label}-${mode}.stderr.log"
+  mkdir -p workload-tmp
+  local start end rc
+  start=$(ms)
+  "$@" >/dev/null 2>"$err_file"
+  rc=$?
+  if [[ $rc -ne 0 ]]; then
+    echo "ERROR: $label mode=$mode rc=$rc — see $err_file" >&2; return $rc
+  fi
+  end=$(ms)
+  awk "BEGIN{printf \"%.1f\",$end-$start}"
+}
+
+test_mean_single() {
+  local test_op="$1" sum=0 n=0
+  for train_op in "${OPS[@]}"; do
+    [[ "$train_op" == "$test_op" ]] && continue
+    local m; m=$(mean_for_key "${train_op}|${test_op}|single")
+    sum=$(awk "BEGIN{printf \"%.4f\",$sum+$m}"); n=$(( n+1 ))
+  done
+  awk -v s="$sum" -v n="$n" 'BEGIN{printf "%.1f",s/n}'
+}
+
+test_stddev_single() {
+  local test_op="$1" all=""
+  for train_op in "${OPS[@]}"; do
+    [[ "$train_op" == "$test_op" ]] && continue
+    all="$all ${samples[${train_op}|${test_op}|single]:-}"
+  done
+  printf "%s\n" $all | awk '{s+=$1;q+=$1*$1;n++}END{if(n<2){print "n/a"}else{printf "%.1f",sqrt((q-s*s/n)/(n-1))}}'
+}
+
+log "Running checkstyle workloads RUNS=$RUNS"
+for RUN_IDX in $(seq 1 "$RUNS"); do
+  printf "  run %2d/%d\n" "$RUN_IDX" "$RUNS"
+  for op in "${OPS[@]}"; do
+    update_stats "${op}|no"   "$(measure_ms "$op" "no"   run_no   "$op")"
+    update_stats "${op}|tree" "$(measure_ms "$op" "tree" run_tree "$op")"
+  done
+  for train_op in "${OPS[@]}"; do
+    for test_op in "${OPS[@]}"; do
+      [[ "$test_op" == "$train_op" ]] && continue
+      update_stats "${train_op}|${test_op}|single" \
+        "$(measure_ms "${train_op}>${test_op}" "single" run_single "$train_op" "$test_op")"
+    done
+  done
+done
+
+print_summary() {
+  echo
+  log "Per-workload timing over ${RUNS} runs (ms) — single uses cache trained on a different op"
+  sep
+  printf "  %-12s | %18s | %20s %8s | %20s %8s\n" \
+    "Workload" "no (mean±SD)" "single (mean±SD)" "su-single" "tree (mean±SD)" "su-tree"
+  sep
+  for op in "${OPS[@]}"; do
+    local m_no m_single m_tree sd_no sd_single sd_tree su_single su_tree
+    m_no=$(mean_for_key "${op}|no")
+    m_single=$(test_mean_single "$op")
+    m_tree=$(mean_for_key "${op}|tree")
+    sd_no=$(stddev_for_key "${op}|no")
+    sd_single=$(test_stddev_single "$op")
+    sd_tree=$(stddev_for_key "${op}|tree")
+    su_single=$(awk -v b="$m_no" -v a="$m_single" 'BEGIN{if(a+0==0){print "n/a"}else{printf "%.2fx",b/a}}')
+    su_tree=$(awk   -v b="$m_no" -v a="$m_tree"   'BEGIN{if(a+0==0){print "n/a"}else{printf "%.2fx",b/a}}')
+    printf "  %-12s | %18s | %20s %8s | %20s %8s\n" \
+      "$op" "${m_no}±${sd_no}" "${m_single}±${sd_single}" "$su_single" "${m_tree}±${sd_tree}" "$su_tree"
+  done
+}
+
+print_latex_rows() {
+  local project="$1"
+  local n="${#OPS[@]}"
+  local tex_file="workload-tmp/latex-rows.tex"
+  local sum_su_single=0 sum_su_tree=0
+  mkdir -p workload-tmp
+  echo "\\multirow{$(( n + 1 ))}{*}{${project}}" > "$tex_file"
+  for op in "${OPS[@]}"; do
+    local m_no m_single m_tree sd_no sd_single sd_tree su_single su_tree fmt_su_single fmt_su_tree
+    m_no=$(mean_for_key "${op}|no")
+    m_single=$(test_mean_single "$op")
+    m_tree=$(mean_for_key "${op}|tree")
+    sd_no=$(stddev_for_key "${op}|no")
+    sd_single=$(test_stddev_single "$op")
+    sd_tree=$(stddev_for_key "${op}|tree")
+    su_single=$(awk -v b="$m_no" -v a="$m_single" 'BEGIN{if(a+0==0){print "n/a"}else{printf "%.2f",b/a}}')
+    su_tree=$(awk   -v b="$m_no" -v a="$m_tree"   'BEGIN{if(a+0==0){print "n/a"}else{printf "%.2f",b/a}}')
+    sum_su_single=$(awk "BEGIN{printf \"%.4f\",$sum_su_single+$su_single}")
+    sum_su_tree=$(awk   "BEGIN{printf \"%.4f\",$sum_su_tree+$su_tree}")
+    fmt_su_single=$(awk -v a="$su_single" -v b="$su_tree" 'BEGIN{if(a+0>b+0) print "\\textbf{"a"x}"; else print a"x"}')
+    fmt_su_tree=$(awk   -v a="$su_single" -v b="$su_tree" 'BEGIN{if(b+0>a+0) print "\\textbf{"b"x}"; else print b"x"}')
+    echo "  & ${op} & \$${m_no} \\pm ${sd_no}\$ & \$${m_single} \\pm ${sd_single}\$ & ${fmt_su_single} & \$${m_tree} \\pm ${sd_tree}\$ & ${fmt_su_tree} \\\\" >> "$tex_file"
+  done
+  local avg_single avg_tree fmt_avg_single fmt_avg_tree
+  avg_single=$(awk -v s="$sum_su_single" -v n="$n" 'BEGIN{printf "%.2f",s/n}')
+  avg_tree=$(awk   -v s="$sum_su_tree"   -v n="$n" 'BEGIN{printf "%.2f",s/n}')
+  fmt_avg_single=$(awk -v a="$avg_single" -v b="$avg_tree" 'BEGIN{if(a+0>b+0) print "\\textbf{"a"x}"; else print a"x"}')
+  fmt_avg_tree=$(awk   -v a="$avg_single" -v b="$avg_tree" 'BEGIN{if(b+0>a+0) print "\\textbf{"b"x}"; else print b"x"}')
+  echo "  & \\textit{Average} & & & ${fmt_avg_single} & & ${fmt_avg_tree} \\\\" >> "$tex_file"
+  echo "\\midrule" >> "$tex_file"
+}
+
+print_summary
+print_latex_rows "checkstyle"


### PR DESCRIPTION
## Summary

- Adds `checkstyle-experiment/` with 5 workloads: **sun**, **google**, **javadoc**, **naming**, **sizes** — each runs a different check configuration against shared Java source files, loading distinct `Check` subclasses
- Submodule: `algomaster99/checkstyle@aotcache-setup` (forked from `checkstyle-13.6.0`, tree-merge profile added)
- Benchmark fat JAR uses `com.puppycrawl.tools:checkstyle:13.6.0` with checkstyle classes excluded; runtime CP is `benchmark-fat.jar:checkstyle/target/classes`
- CI workflow: `checkstyle-aot-cache.yml`

## Test plan

- [ ] `cd checkstyle-experiment/checkstyle && mvn clean test -P tree-merge -Dmaven.test.failure.ignore=true` produces `cache.aot`
- [ ] `cd checkstyle-experiment/benchmark && mvn package -DskipTests` produces `benchmark-fat.jar`
- [ ] `./create-single-aot.sh` produces `single-{sun,google,javadoc,naming,sizes}.aot`
- [ ] `./orchestrate-combine.sh` produces `tree.aot`
- [ ] `./workload-timed.sh` completes 30 runs and prints summary + LaTeX rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)