### PR TITLE
Add certificate-ripper AOT cache experiment

### DIFF
--- a/.github/workflows/certificate-ripper-aot-cache.yml
+++ b/.github/workflows/certificate-ripper-aot-cache.yml
@@ -1,0 +1,158 @@
+name: Certificate Ripper AOT Cache
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  tree-combine:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          submodules: false
+
+      - name: Init certificate-ripper submodule
+        run: |
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
+          git submodule update --init -- \
+            certificate-ripper-experiment/certificate-ripper
+
+      - name: Download custom JDK
+        uses: ./.github/actions/download-custom-jdk
+
+      - name: Set up custom JDK
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: jdkfile
+          java-version: '25'
+          jdkFile: jdk-custom.tar.gz
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-crip-${{ hashFiles('certificate-ripper-experiment/**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-crip-
+            ${{ runner.os }}-maven-
+
+      - name: Build fat jar and run tree-merge tests
+        working-directory: certificate-ripper-experiment/certificate-ripper
+        run: |
+          set -euo pipefail
+          rm -f cache.aot
+          mvn package -Ptree-merge -q
+          test -f cache.aot
+          test -f target/crip.jar
+
+      # ── single.aot (Temurin — no-AOT baseline JDK) ──────────────────────────
+
+      - name: Set up JDK 24 (no-AOT baseline and single.aot)
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: temurin
+          java-version: '24'
+
+      - name: Capture Temurin JDK path
+        run: echo "TEMURIN_JAVA_HOME=$JAVA_HOME" >> "$GITHUB_ENV"
+
+      - name: Create single.aot (JDK 24)
+        working-directory: certificate-ripper-experiment
+        run: |
+          set -euo pipefail
+          chmod +x create-single-aot.sh
+          ./create-single-aot.sh
+          for op in print-https export-pem-https print-smtps; do
+            test -f "single-${op}.aot"
+          done
+
+      # ── tree.aot (custom JDK) ─────────────────────────────────────────────
+
+      - name: Re-enable custom JDK
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: jdkfile
+          java-version: '25'
+          jdkFile: jdk-custom.tar.gz
+
+      - name: Create tree.aot (orchestrate-combine.sh)
+        working-directory: certificate-ripper-experiment
+        run: |
+          set -euo pipefail
+          chmod +x orchestrate-combine.sh
+          combine_out=$(./orchestrate-combine.sh 2>&1) || { echo "$combine_out"; exit 1; }
+          echo "$combine_out"
+          combine_out_clean=$(echo "$combine_out" | sed 's/\x1B\[[0-9;]*m//g')
+
+          tree_size=$(du -h tree.aot | awk '{print $1}')
+
+          {
+            echo "## tree.aot creation (orchestrate-combine)"
+            echo
+            echo "- tree.aot: ${tree_size}"
+            echo
+            echo '```'
+            echo "$combine_out_clean"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          test -f tree.aot
+
+      # ── timed workload ───────────────────────────────────────────────────────
+
+      - name: Run timed workload
+        working-directory: certificate-ripper-experiment
+        run: |
+          set -euo pipefail
+          chmod +x workload-timed.sh
+          wl_out=$(JAVA_NO_BIN="$TEMURIN_JAVA_HOME/bin/java" \
+                   JAVA_AOTCACHE_BIN="$TEMURIN_JAVA_HOME/bin/java" \
+                   JAVA_TREECACHE_BIN="$JAVA_HOME/bin/java" \
+                   ./workload-timed.sh 2>&1) || { echo "$wl_out"; exit 1; }
+          echo "$wl_out"
+          wl_out_clean=$(echo "$wl_out" | sed 's/\x1B\[[0-9;]*m//g')
+
+          single_size=$(du -ch single-*.aot | tail -1 | awk '{print $1}')
+          tree_size=$(du -h tree.aot | awk '{print $1}')
+
+          {
+            echo "## Timed workload results (no-AOT vs AOTCache vs TreeCache)"
+            echo
+            echo "- single-*.aot total: ${single_size}"
+            echo "- tree.aot: ${tree_size}"
+            echo
+            echo '```'
+            echo "$wl_out_clean"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Append LaTeX table rows to summary
+        working-directory: certificate-ripper-experiment
+        run: |
+          {
+            echo "## LaTeX table rows (single=AOTCache, tree=TreeCache)"
+            echo
+            echo '```latex'
+            cat workload-tmp/latex-rows.tex
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: certificate-ripper-tree-artifacts
+          path: |
+            certificate-ripper-experiment/workload-tmp/
+            certificate-ripper-experiment/single-print-https.aot
+            certificate-ripper-experiment/single-export-pem-https.aot
+            certificate-ripper-experiment/single-print-smtps.aot
+            certificate-ripper-experiment/cli-print-https.aot
+            certificate-ripper-experiment/cli-export-pem-https.aot
+            certificate-ripper-experiment/cli-print-smtps.aot
+            certificate-ripper-experiment/tree.aot
+            certificate-ripper-experiment/certificate-ripper/cache.aot
+          if-no-files-found: error

--- a/.github/workflows/certificate-ripper-aot-cache.yml
+++ b/.github/workflows/certificate-ripper-aot-cache.yml
@@ -45,7 +45,10 @@ jobs:
         run: |
           set -euo pipefail
           rm -f cache.aot
-          mvn package -Ptree-merge -q
+          # maven.test.failure.ignore: Netty disables sun.misc.Unsafe on JDK 25+ which
+          # crashes the embedded ssl-server @BeforeAll, but the JVM still loads classes
+          # and writes cache.aot on shutdown — so we get useful cache coverage despite errors.
+          mvn package -Ptree-merge -Dmaven.test.failure.ignore=true -q
           test -f cache.aot
           test -f target/crip.jar
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -109,3 +109,7 @@
 	path = opennlp-experiment/opennlp-deps/morfologik
 	url = git@github.com:algomaster99/morfologik-stemming.git
 	branch = aot-profiles
+[submodule "certificate-ripper-experiment/certificate-ripper"]
+	path = certificate-ripper-experiment/certificate-ripper
+	url = git@github.com:algomaster99/certificate-ripper.git
+	branch = upstream-2.7.1

--- a/certificate-ripper-experiment/create-single-aot.sh
+++ b/certificate-ripper-experiment/create-single-aot.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Records one single-{op}.aot per workload using the crip fat jar.
+set -euo pipefail
+
+log()  { echo -e "\033[1;32m[$(date '+%H:%M:%S')] $*\033[0m"; }
+fail() { echo -e "\033[1;31mERROR: $*\033[0m" >&2; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+log "Java version:"
+java -version
+
+JAR="certificate-ripper/target/crip.jar"
+[[ -f "$JAR" ]] || fail "$JAR not found — run: mvn package -DskipTests in certificate-ripper/"
+
+OPS=(print-https export-pem-https print-smtps)
+EXPORT_DIR="$SCRIPT_DIR/workload-tmp/exports"
+mkdir -p "$EXPORT_DIR/pem"
+
+_crip_args() {
+  case "$1" in
+    print-https)     echo "print --url https://github.com --resolve-ca false" ;;
+    export-pem-https) echo "export pem --url https://github.com --resolve-ca false -d $EXPORT_DIR/pem" ;;
+    print-smtps)     echo "print --url smtps://smtp.gmail.com:465 --resolve-ca false" ;;
+  esac
+}
+
+for op in "${OPS[@]}"; do
+  aot="single-${op}.aot"
+  conf="single-${op}.aotconf"
+  if [[ -f "$aot" ]]; then
+    log "$aot already exists, skipping."
+    continue
+  fi
+
+  log "Recording $aot (step 1: AOTConfiguration)"
+  rm -f "$conf"
+  read -ra args <<< "$(_crip_args "$op")"
+  java -XX:AOTMode=record -XX:AOTConfiguration="$conf" \
+    -XX:+AOTClassLinking \
+    -jar "$JAR" "${args[@]}" >/dev/null 2>/dev/null || true
+
+  [[ -f "$conf" ]] || fail "AOTConfiguration not produced for $op"
+
+  log "Recording $aot (step 2: AOTCache)"
+  java -XX:AOTMode=create -XX:AOTConfiguration="$conf" \
+    -XX:AOTCache="$aot" \
+    -XX:+AOTClassLinking \
+    -jar "$JAR"
+
+  [[ -f "$aot" ]] || fail "$aot was not created"
+  log "$aot created ($(du -sh "$aot" | cut -f1))"
+done

--- a/certificate-ripper-experiment/orchestrate-combine.sh
+++ b/certificate-ripper-experiment/orchestrate-combine.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -euo pipefail
+
+log()  { echo -e "\033[1;32m[$(date '+%H:%M:%S')] $*\033[0m"; }
+fail() { echo -e "\033[1;31mERROR: $*\033[0m" >&2; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+log "Java version:"
+java -version
+
+JAR="certificate-ripper/target/crip.jar"
+[[ -f "$JAR" ]] || fail "$JAR not found"
+[[ -f "certificate-ripper/cache.aot" ]] || fail "certificate-ripper/cache.aot not found — run: mvn test -Ptree-merge"
+
+OPS=(print-https export-pem-https print-smtps)
+EXPORT_DIR="$SCRIPT_DIR/workload-tmp/exports"
+mkdir -p "$EXPORT_DIR/pem"
+
+_crip_args() {
+  case "$1" in
+    print-https)      echo "print --url https://github.com --resolve-ca false" ;;
+    export-pem-https) echo "export pem --url https://github.com --resolve-ca false -d $EXPORT_DIR/pem" ;;
+    print-smtps)      echo "print --url smtps://smtp.gmail.com:465 --resolve-ca false" ;;
+  esac
+}
+
+# ── record CLI workload caches (covers CLI-specific classes not in test suite) ─
+
+CLI_CACHES=()
+for op in "${OPS[@]}"; do
+  cli_aot="cli-${op}.aot"
+  cli_conf="cli-${op}.aotconf"
+  if [[ -f "$cli_aot" ]]; then
+    log "$cli_aot already exists, reusing"
+  else
+    log "Recording CLI cache for $op (step 1: AOTConfiguration)"
+    rm -f "$cli_conf"
+    read -ra args <<< "$(_crip_args "$op")"
+    java -XX:AOTMode=record -XX:AOTConfiguration="$cli_conf" \
+      -XX:+AOTClassLinking \
+      -jar "$JAR" "${args[@]}" >/dev/null 2>/dev/null || true
+    [[ -f "$cli_conf" ]] || fail "AOTConfiguration not produced for $op"
+
+    log "Recording CLI cache for $op (step 2: AOTCache)"
+    java -XX:AOTMode=create -XX:AOTConfiguration="$cli_conf" \
+      -XX:AOTCache="$cli_aot" \
+      -XX:+AOTClassLinking \
+      -jar "$JAR"
+    [[ -f "$cli_aot" ]] || fail "$cli_aot not created"
+    log "$cli_aot created ($(du -sh "$cli_aot" | cut -f1))"
+  fi
+  CLI_CACHES+=("$cli_aot")
+done
+
+# ── merge all caches → tree.aot ───────────────────────────────────────────────
+
+ALL_CACHES=("certificate-ripper/cache.aot" "${CLI_CACHES[@]}")
+BASE_AOT="${ALL_CACHES[0]}"
+MERGE_INPUTS="$(IFS=:; echo "${ALL_CACHES[*]}")"
+OUTPUT_AOT="tree.aot"
+
+rm -f "$OUTPUT_AOT"
+
+log "Merging ${#ALL_CACHES[@]} caches → $OUTPUT_AOT"
+java \
+  -Xlog:aot=info \
+  -Xlog:aot+map=trace,aot+map+oops=trace,aot=warning:file=aot.map:none:filesize=0 \
+  -XX:AOTMode=merge \
+  -XX:AOTCache="$BASE_AOT" \
+  -XX:AOTMergeInputs="$MERGE_INPUTS" \
+  -XX:AOTCacheOutput="$OUTPUT_AOT" \
+  -jar "$JAR" \
+  --help >/dev/null 2>&1 || true
+
+[[ -f "$OUTPUT_AOT" ]] || fail "tree.aot was not created"
+log "$OUTPUT_AOT created ($(du -sh "$OUTPUT_AOT" | cut -f1))"

--- a/certificate-ripper-experiment/workload-timed.sh
+++ b/certificate-ripper-experiment/workload-timed.sh
@@ -1,0 +1,220 @@
+#!/bin/bash
+set -euo pipefail
+
+log()  { echo -e "\033[1;32m[$(date '+%H:%M:%S')] $*\033[0m"; }
+sep()  { echo -e "\033[0;90m  $(printf '─%.0s' {1..60})\033[0m"; }
+fail() { echo -e "\033[1;31mERROR: $*\033[0m" >&2; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+JAR="certificate-ripper/target/crip.jar"
+TREECACHE_AOT="tree.aot"
+WORK_DIR="workload-tmp"
+
+RUNS="${RUNS:-30}"
+JAVA_NO_BIN="${JAVA_NO_BIN:-java}"
+JAVA_AOTCACHE_BIN="${JAVA_AOTCACHE_BIN:-java}"
+JAVA_TREECACHE_BIN="${JAVA_TREECACHE_BIN:-java}"
+
+OPS=(print-https export-pem-https print-smtps)
+EXPORT_DIR="$SCRIPT_DIR/$WORK_DIR/exports"
+mkdir -p "$EXPORT_DIR/pem" "$WORK_DIR"
+
+[[ -f "$JAR" ]] || fail "$JAR not found"
+for _op in "${OPS[@]}"; do
+  [[ -f "single-${_op}.aot" ]] || fail "single-${_op}.aot not found — run ./create-single-aot.sh first"
+done
+[[ -f "$TREECACHE_AOT" ]] || fail "tree.aot not found — run ./orchestrate-combine.sh first"
+
+_crip_args() {
+  case "$1" in
+    print-https)      echo "print --url https://github.com --resolve-ca false" ;;
+    export-pem-https) echo "export pem --url https://github.com --resolve-ca false -d $EXPORT_DIR/pem" ;;
+    print-smtps)      echo "print --url smtps://smtp.gmail.com:465 --resolve-ca false" ;;
+  esac
+}
+
+log "Java binaries:"
+printf "  no-AOT:    %s\n" "$JAVA_NO_BIN";       "$JAVA_NO_BIN"       -version 2>&1 | head -1
+printf "  AOTCache:  %s\n" "$JAVA_AOTCACHE_BIN"; "$JAVA_AOTCACHE_BIN" -version 2>&1 | head -1
+printf "  TreeCache: %s\n" "$JAVA_TREECACHE_BIN"; "$JAVA_TREECACHE_BIN" -version 2>&1 | head -1
+echo
+
+# ── timing helpers ────────────────────────────────────────────────────────────
+
+ms() { date +%s%N | awk '{printf "%.1f", $1/1000000}'; }
+
+declare -A _samples
+
+_update() { _samples[$1]="${_samples[$1]:-} $2"; }
+
+_mean() {
+  local s="${_samples[$1]:-}"
+  [[ -z "$s" ]] && { echo "n/a"; return; }
+  printf "%s\n" $s | awk '{sum+=$1;n++} END{if(!n)print "n/a"; else printf "%.1f",sum/n}'
+}
+
+_stddev() {
+  local s="${_samples[$1]:-}"
+  [[ -z "$s" ]] && { echo "n/a"; return; }
+  printf "%s\n" $s | awk '{sum+=$1;sumsq+=$1*$1;n++} END{if(n<2)print "n/a"; else printf "%.1f",sqrt((sumsq-sum*sum/n)/(n-1))}'
+}
+
+_measure() {
+  local key="$1" op="$2" java_bin="$3"
+  shift 3
+  local errfile="$WORK_DIR/${key//|/-}.err"
+  local t0 t1 rc=0
+  read -ra args <<< "$(_crip_args "$op")"
+  t0=$(ms)
+  "$java_bin" "$@" -jar "$JAR" "${args[@]}" >/dev/null 2>"$errfile" || rc=$?
+  t1=$(ms)
+  if (( rc != 0 )); then
+    echo "  WARN: key=$key exited $rc — see $errfile" >&2
+    return
+  fi
+  _update "$key" "$(awk "BEGIN{printf \"%.1f\",$t1-$t0}")"
+}
+
+# ── main loop ─────────────────────────────────────────────────────────────────
+
+log "Running $RUNS iterations × ${#OPS[@]} ops (cross-workload)"
+sep
+
+for run in $(seq 1 "$RUNS"); do
+  printf "  run %2d/%d\n" "$run" "$RUNS"
+  for op in "${OPS[@]}"; do
+    _measure "${op}|no"        "$op" "$JAVA_NO_BIN"
+    _measure "${op}|TreeCache" "$op" "$JAVA_TREECACHE_BIN" \
+      -XX:AOTCache="$TREECACHE_AOT" -XX:+AOTClassLinking
+  done
+  for train_op in "${OPS[@]}"; do
+    for test_op in "${OPS[@]}"; do
+      [[ "$test_op" == "$train_op" ]] && continue
+      _measure "${train_op}|${test_op}|aotcache" "$test_op" "$JAVA_AOTCACHE_BIN" \
+        -XX:AOTCache="single-${train_op}.aot" -XX:+AOTClassLinking
+    done
+  done
+done
+
+# ── results ───────────────────────────────────────────────────────────────────
+
+_test_mean_aotcache() {
+  local test_op="$1" sum=0 n=0 train_op m
+  for train_op in "${OPS[@]}"; do
+    [[ "$train_op" == "$test_op" ]] && continue
+    m=$(_mean "${train_op}|${test_op}|aotcache")
+    [[ "$m" == "n/a" ]] && continue
+    sum=$(awk "BEGIN{printf \"%.4f\",$sum+$m}")
+    n=$(( n + 1 ))
+  done
+  [[ $n -eq 0 ]] && { echo "n/a"; return; }
+  awk -v s="$sum" -v n="$n" 'BEGIN{printf "%.1f",s/n}'
+}
+
+_test_stddev_aotcache() {
+  local test_op="$1" all="" train_op
+  for train_op in "${OPS[@]}"; do
+    [[ "$train_op" == "$test_op" ]] && continue
+    all="$all ${_samples[${train_op}|${test_op}|aotcache]:-}"
+  done
+  printf "%s\n" $all | awk '{sum+=$1;sumsq+=$1*$1;n++} END{if(n<2)print "n/a"; else printf "%.1f",sqrt((sumsq-sum*sum/n)/(n-1))}'
+}
+
+echo
+log "Per-workload timing over $RUNS runs (ms) — AOTCache uses caches trained on other ops"
+sep
+printf "  %-20s | %18s | %20s %12s | %20s %12s\n" \
+  "Workload" "no (mean±SD)" "aotcache (mean±SD)" "su-aotcache" "TreeCache (mean±SD)" "su-TreeCache"
+sep
+for op in "${OPS[@]}"; do
+  m_no=$(_mean "${op}|no")
+  m_mono=$(_test_mean_aotcache "$op")
+  m_tree=$(_mean "${op}|TreeCache")
+  sd_no=$(_stddev "${op}|no")
+  sd_mono=$(_test_stddev_aotcache "$op")
+  sd_tree=$(_stddev "${op}|TreeCache")
+  su_mono=$(awk -v b="$m_no" -v a="$m_mono" 'BEGIN{if(a+0==0){print "n/a"}else{printf "%.2fx",b/a}}')
+  su_tree=$(awk -v b="$m_no" -v a="$m_tree" 'BEGIN{if(a+0==0){print "n/a"}else{printf "%.2fx",b/a}}')
+  printf "  %-20s | %18s | %20s %12s | %20s %12s\n" \
+    "$op" "${m_no}±${sd_no}" "${m_mono}±${sd_mono}" "$su_mono" "${m_tree}±${sd_tree}" "$su_tree"
+done
+
+# ── LaTeX rows ────────────────────────────────────────────────────────────────
+
+_print_latex_rows() {
+  local project="$1" n="${#OPS[@]}" tex_file="$WORK_DIR/latex-rows.tex"
+  local sum_su_mono=0 sum_su_tree=0 cnt_mono=0 cnt_tree=0
+  echo "\\multirow{$(( n + 1 ))}{*}{${project}}" > "$tex_file"
+  for op in "${OPS[@]}"; do
+    local m_no m_mono m_tree sd_no sd_mono sd_tree su_mono su_tree fmt_mono fmt_tree
+    m_no=$(_mean "${op}|no");          sd_no=$(_stddev "${op}|no")
+    m_mono=$(_test_mean_aotcache "$op"); sd_mono=$(_test_stddev_aotcache "$op")
+    m_tree=$(_mean "${op}|TreeCache"); sd_tree=$(_stddev "${op}|TreeCache")
+    su_mono=$(awk -v b="$m_no" -v a="$m_mono" 'BEGIN{if(a+0==0){print "n/a"}else{printf "%.2f",b/a}}')
+    su_tree=$(awk -v b="$m_no" -v a="$m_tree" 'BEGIN{if(a+0==0){print "n/a"}else{printf "%.2f",b/a}}')
+    if [[ "$su_mono" != "n/a" ]]; then
+      sum_su_mono=$(awk "BEGIN{printf \"%.4f\",$sum_su_mono+$su_mono}"); cnt_mono=$(( cnt_mono+1 ))
+    fi
+    if [[ "$su_tree" != "n/a" ]]; then
+      sum_su_tree=$(awk "BEGIN{printf \"%.4f\",$sum_su_tree+$su_tree}"); cnt_tree=$(( cnt_tree+1 ))
+    fi
+    fmt_mono=$(awk -v a="$su_mono" -v b="$su_tree" 'BEGIN{if(a+0>b+0) print "\\textbf{"a"x}"; else print a"x"}')
+    fmt_tree=$(awk -v a="$su_mono" -v b="$su_tree" 'BEGIN{if(b+0>a+0) print "\\textbf{"b"x}"; else print b"x"}')
+    echo "  & ${op} & \$${m_no} \pm ${sd_no}\$ & \$${m_mono} \pm ${sd_mono}\$ & ${fmt_mono} & \$${m_tree} \pm ${sd_tree}\$ & ${fmt_tree} \\\\" >> "$tex_file"
+  done
+  local avg_mono avg_tree fmt_avg_mono fmt_avg_tree
+  avg_mono=$(awk -v s="$sum_su_mono" -v c="$cnt_mono" 'BEGIN{if(c==0)print "n/a"; else printf "%.2f",s/c}')
+  avg_tree=$(awk -v s="$sum_su_tree"  -v c="$cnt_tree"  'BEGIN{if(c==0)print "n/a"; else printf "%.2f",s/c}')
+  fmt_avg_mono=$(awk -v a="$avg_mono" -v b="$avg_tree" 'BEGIN{if(a+0>b+0) print "\\textbf{"a"x}"; else print a"x"}')
+  fmt_avg_tree=$(awk -v a="$avg_mono" -v b="$avg_tree" 'BEGIN{if(b+0>a+0) print "\\textbf{"b"x}"; else print b"x"}')
+  echo "  & \\textit{Average} & & & ${fmt_avg_mono} & & ${fmt_avg_tree} \\\\" >> "$tex_file"
+  echo "\\midrule" >> "$tex_file"
+}
+
+_print_latex_rows "certificate-ripper"
+
+# ── class-load breakdown ──────────────────────────────────────────────────────
+
+_classload_row() {
+  local op="$1" mode="$2"
+  local logfile="$WORK_DIR/cl-${op}-${mode}.log"
+  local rc=0
+  read -ra args <<< "$(_crip_args "$op")"
+  case "$mode" in
+    no)
+      "$JAVA_NO_BIN" \
+        -Xlog:class+load:file="$logfile" \
+        -jar "$JAR" "${args[@]}" >/dev/null 2>&1 || rc=$? ;;
+    AOTCache)
+      "$JAVA_AOTCACHE_BIN" \
+        -XX:AOTCache="single-${op}.aot" -XX:+AOTClassLinking \
+        -Xlog:class+load:file="$logfile" \
+        -jar "$JAR" "${args[@]}" >/dev/null 2>&1 || rc=$? ;;
+    TreeCache)
+      "$JAVA_TREECACHE_BIN" \
+        -XX:AOTCache="$TREECACHE_AOT" -XX:+AOTClassLinking \
+        -Xlog:class+load:file="$logfile" \
+        -jar "$JAR" "${args[@]}" >/dev/null 2>&1 || rc=$? ;;
+  esac
+  if (( rc != 0 )); then
+    printf "  %-22s | %-9s | %8s | %8s\n" "$op" "$mode" "n/a" "n/a"
+    return
+  fi
+  printf "  %-22s | %-9s | %8s | %8s\n" "$op" "$mode" \
+    "$(awk '/source: file:/{c++} END{print c+0}' "$logfile")" \
+    "$(awk '/source: shared objects/{c++} END{print c+0}' "$logfile")"
+}
+
+echo
+log "Class-load source breakdown (AOTCache uses same-workload cache)"
+sep
+printf "  %-22s | %-9s | %8s | %8s\n" "Operation" "Mode" "file:" "shared"
+sep
+for op in "${OPS[@]}"; do
+  for mode in no AOTCache TreeCache; do
+    _classload_row "$op" "$mode"
+  done
+  sep
+done


### PR DESCRIPTION
## Summary

- New experiment for [certificate-ripper 2.7.1](https://github.com/Hakky54/certificate-ripper/releases/tag/2.7.1), a picocli-based CLI tool that extracts TLS certificates
- Single-module project — no dependency forks needed
- Workloads cover **two axes** of variation for cross-workload comparison:
  - **Protocol**: HTTPS vs SMTPS (`SmtpClientRunnable` + commons-net loads different classes than `HttpClient`)
  - **Output format**: `print` (console) vs `export pem` (file write + PEM encoding)

## Workloads
| Op | Command |
|---|---|
| `print-https` | `print --url https://github.com --resolve-ca false` |
| `export-pem-https` | `export pem --url https://github.com --resolve-ca false` |
| `print-smtps` | `print --url smtps://smtp.gmail.com:465 --resolve-ca false` |

## Test plan
- [ ] CI passes `Build fat jar and run tree-merge tests`
- [ ] `Create single.aot` produces 3 `.aot` files
- [ ] `Create tree.aot` merges 4 caches (1 test suite + 3 CLI) successfully
- [ ] `Run timed workload` produces speedup numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)