### PR TITLE
Add Apache Tika 3.3.1 AOT cache experiment

### DIFF
--- a/.github/workflows/tika-aot-cache.yml
+++ b/.github/workflows/tika-aot-cache.yml
@@ -81,6 +81,77 @@ jobs:
           mvn clean test -Ptree-merge -pl "$MSFT_MODULE" -q --no-transfer-progress
           test -f "$MSFT_MODULE/cache.aot"
 
+      - name: Build tika-serialization cache (tree-merge)
+        working-directory: tika-experiment/tika
+        run: |
+          set -euo pipefail
+          find tika-serialization -name "*.aot" -type f -delete
+          mvn clean test -Ptree-merge -pl tika-serialization -q --no-transfer-progress
+          test -f tika-serialization/cache.aot
+
+      - name: Build tika-parser-image-module cache (tree-merge)
+        working-directory: tika-experiment/tika
+        run: |
+          set -euo pipefail
+          IMG_MODULE="tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-image-module"
+          find "$IMG_MODULE" -name "*.aot" -type f -delete
+          mvn clean test -Ptree-merge -pl "$IMG_MODULE" -q --no-transfer-progress
+          test -f "$IMG_MODULE/cache.aot"
+
+      - name: Build tika-parser-pkg-module cache (tree-merge)
+        working-directory: tika-experiment/tika
+        run: |
+          set -euo pipefail
+          PKG_MODULE="tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pkg-module"
+          find "$PKG_MODULE" -name "*.aot" -type f -delete
+          mvn clean test -Ptree-merge -pl "$PKG_MODULE" -q --no-transfer-progress
+          test -f "$PKG_MODULE/cache.aot"
+
+      - name: Build tika-parser-code-module cache (tree-merge)
+        working-directory: tika-experiment/tika
+        run: |
+          set -euo pipefail
+          CODE_MODULE="tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-code-module"
+          find "$CODE_MODULE" -name "*.aot" -type f -delete
+          mvn clean test -Ptree-merge -pl "$CODE_MODULE" -q --no-transfer-progress
+          test -f "$CODE_MODULE/cache.aot"
+
+      - name: Build tika-parser-audiovideo-module cache (tree-merge)
+        working-directory: tika-experiment/tika
+        run: |
+          set -euo pipefail
+          AV_MODULE="tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-audiovideo-module"
+          find "$AV_MODULE" -name "*.aot" -type f -delete
+          mvn clean test -Ptree-merge -pl "$AV_MODULE" -q --no-transfer-progress
+          test -f "$AV_MODULE/cache.aot"
+
+      - name: Build tika-parser-miscoffice-module cache (tree-merge)
+        working-directory: tika-experiment/tika
+        run: |
+          set -euo pipefail
+          MISC_MODULE="tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-miscoffice-module"
+          find "$MISC_MODULE" -name "*.aot" -type f -delete
+          mvn clean test -Ptree-merge -pl "$MISC_MODULE" -q --no-transfer-progress
+          test -f "$MISC_MODULE/cache.aot"
+
+      - name: Build tika-parser-apple-module cache (tree-merge)
+        working-directory: tika-experiment/tika
+        run: |
+          set -euo pipefail
+          APPLE_MODULE="tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-apple-module"
+          find "$APPLE_MODULE" -name "*.aot" -type f -delete
+          mvn clean test -Ptree-merge -pl "$APPLE_MODULE" -q --no-transfer-progress
+          test -f "$APPLE_MODULE/cache.aot"
+
+      - name: Build tika-parser-webarchive-module cache (tree-merge)
+        working-directory: tika-experiment/tika
+        run: |
+          set -euo pipefail
+          WEB_MODULE="tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-webarchive-module"
+          find "$WEB_MODULE" -name "*.aot" -type f -delete
+          mvn clean test -Ptree-merge -pl "$WEB_MODULE" -q --no-transfer-progress
+          test -f "$WEB_MODULE/cache.aot"
+
       # ── single.aot (Temurin — no-AOT baseline JDK) ──────────────────────────
 
       - name: Set up JDK ${{ inputs.single_aot_jdk || '24' }} (no-AOT baseline and single.aot)
@@ -184,6 +255,14 @@ jobs:
             tika-experiment/single-text-html.aot
             tika-experiment/tree.aot
             tika-experiment/tika/tika-core/cache.aot
+            tika-experiment/tika/tika-serialization/cache.aot
             tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pdf-module/cache.aot
             tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-image-module/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pkg-module/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-code-module/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-audiovideo-module/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-miscoffice-module/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-apple-module/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-webarchive-module/cache.aot
           if-no-files-found: error

--- a/.github/workflows/tika-aot-cache.yml
+++ b/.github/workflows/tika-aot-cache.yml
@@ -214,7 +214,7 @@ jobs:
           set -euo pipefail
           chmod +x create-single-aot.sh
           ./create-single-aot.sh
-          for op in text-pdf text-docx text-numbers; do
+          for op in text-pdf text-docx text-archive; do
             test -f "single-${op}.aot"
           done
 
@@ -297,7 +297,7 @@ jobs:
             tika-experiment/workload-tmp/
             tika-experiment/single-text-pdf.aot
             tika-experiment/single-text-docx.aot
-            tika-experiment/single-text-numbers.aot
+            tika-experiment/single-text-archive.aot
             tika-experiment/tree.aot
             tika-experiment/tika/tika-core/cache.aot
             tika-experiment/tika/tika-serialization/cache.aot

--- a/.github/workflows/tika-aot-cache.yml
+++ b/.github/workflows/tika-aot-cache.yml
@@ -152,6 +152,51 @@ jobs:
           mvn clean test -Ptree-merge -pl "$WEB_MODULE" -q --no-transfer-progress
           test -f "$WEB_MODULE/cache.aot"
 
+      - name: Build tika-parser-crypto-module cache (tree-merge)
+        working-directory: tika-experiment/tika
+        run: |
+          set -euo pipefail
+          CRYPTO_MODULE="tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-crypto-module"
+          find "$CRYPTO_MODULE" -name "*.aot" -type f -delete
+          mvn clean test -Ptree-merge -pl "$CRYPTO_MODULE" -q --no-transfer-progress
+          test -f "$CRYPTO_MODULE/cache.aot"
+
+      - name: Build tika-parser-cad-module cache (tree-merge)
+        working-directory: tika-experiment/tika
+        run: |
+          set -euo pipefail
+          CAD_MODULE="tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-cad-module"
+          find "$CAD_MODULE" -name "*.aot" -type f -delete
+          mvn clean test -Ptree-merge -pl "$CAD_MODULE" -q --no-transfer-progress
+          test -f "$CAD_MODULE/cache.aot"
+
+      - name: Build tika-parser-font-module cache (tree-merge)
+        working-directory: tika-experiment/tika
+        run: |
+          set -euo pipefail
+          FONT_MODULE="tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-font-module"
+          find "$FONT_MODULE" -name "*.aot" -type f -delete
+          mvn clean test -Ptree-merge -pl "$FONT_MODULE" -q --no-transfer-progress
+          test -f "$FONT_MODULE/cache.aot"
+
+      - name: Build tika-parser-news-module cache (tree-merge)
+        working-directory: tika-experiment/tika
+        run: |
+          set -euo pipefail
+          NEWS_MODULE="tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-news-module"
+          find "$NEWS_MODULE" -name "*.aot" -type f -delete
+          mvn clean test -Ptree-merge -pl "$NEWS_MODULE" -q --no-transfer-progress
+          test -f "$NEWS_MODULE/cache.aot"
+
+      - name: Build tika-parsers-standard-package cache (tree-merge)
+        working-directory: tika-experiment/tika
+        run: |
+          set -euo pipefail
+          PKG="tika-parsers/tika-parsers-standard/tika-parsers-standard-package"
+          find "$PKG" -name "*.aot" -type f -delete
+          mvn clean test -Ptree-merge -pl "$PKG" -q --no-transfer-progress
+          test -f "$PKG/cache.aot"
+
       # ── single.aot (Temurin — no-AOT baseline JDK) ──────────────────────────
 
       - name: Set up JDK ${{ inputs.single_aot_jdk || '24' }} (no-AOT baseline and single.aot)
@@ -265,4 +310,9 @@ jobs:
             tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-miscoffice-module/cache.aot
             tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-apple-module/cache.aot
             tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-webarchive-module/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-crypto-module/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-cad-module/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-font-module/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-news-module/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-package/cache.aot
           if-no-files-found: error

--- a/.github/workflows/tika-aot-cache.yml
+++ b/.github/workflows/tika-aot-cache.yml
@@ -1,0 +1,190 @@
+name: Apache Tika AOT Cache
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      single_aot_jdk:
+        description: 'JDK version used for single.aot and no-AOT baseline'
+        required: false
+        default: '24'
+        type: choice
+        options:
+          - '25'
+          - '24'
+
+jobs:
+  tree-combine:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          submodules: false
+
+      - name: Init tika submodule
+        run: |
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
+          git submodule update --init -- \
+            tika-experiment/tika
+
+      - name: Download custom JDK
+        uses: ./.github/actions/download-custom-jdk
+
+      - name: Set up custom JDK
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: jdkfile
+          java-version: '25'
+          jdkFile: jdk-custom.tar.gz
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-tika-${{ hashFiles('tika-experiment/tika/**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-tika-
+            ${{ runner.os }}-maven-
+
+      - name: Build tika fat jar (skip tests)
+        working-directory: tika-experiment/tika
+        run: mvn install -DskipTests -q --no-transfer-progress
+
+      - name: Build tika-core cache (tree-merge)
+        working-directory: tika-experiment/tika
+        run: |
+          set -euo pipefail
+          find tika-core -name "*.aot" -type f -delete
+          mvn clean test -Ptree-merge -pl tika-core -q --no-transfer-progress
+          test -f tika-core/cache.aot
+
+      - name: Build tika-parser-pdf-module cache (tree-merge)
+        working-directory: tika-experiment/tika
+        run: |
+          set -euo pipefail
+          PDF_MODULE="tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pdf-module"
+          find "$PDF_MODULE" -name "*.aot" -type f -delete
+          mvn clean test -Ptree-merge -pl "$PDF_MODULE" -q --no-transfer-progress
+          test -f "$PDF_MODULE/cache.aot"
+
+      - name: Build tika-parser-microsoft-module cache (tree-merge)
+        working-directory: tika-experiment/tika
+        run: |
+          set -euo pipefail
+          MSFT_MODULE="tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module"
+          find "$MSFT_MODULE" -name "*.aot" -type f -delete
+          mvn clean test -Ptree-merge -pl "$MSFT_MODULE" -q --no-transfer-progress
+          test -f "$MSFT_MODULE/cache.aot"
+
+      # ── single.aot (Temurin — no-AOT baseline JDK) ──────────────────────────
+
+      - name: Set up JDK ${{ inputs.single_aot_jdk || '24' }} (no-AOT baseline and single.aot)
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: temurin
+          java-version: ${{ inputs.single_aot_jdk || '24' }}
+
+      - name: Capture Temurin JDK path
+        run: echo "TEMURIN_JAVA_HOME=$JAVA_HOME" >> "$GITHUB_ENV"
+
+      - name: Create single.aot (JDK ${{ inputs.single_aot_jdk || '24' }})
+        working-directory: tika-experiment
+        run: |
+          set -euo pipefail
+          chmod +x create-single-aot.sh
+          ./create-single-aot.sh
+          for op in text-pdf text-docx text-html; do
+            test -f "single-${op}.aot"
+          done
+
+      # ── tree.aot (custom JDK) ─────────────────────────────────────────────
+
+      - name: Re-enable custom JDK
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: jdkfile
+          java-version: '25'
+          jdkFile: jdk-custom.tar.gz
+
+      - name: Create tree.aot (orchestrate-combine.sh)
+        working-directory: tika-experiment
+        run: |
+          set -euo pipefail
+          chmod +x orchestrate-combine.sh
+          combine_out=$(./orchestrate-combine.sh 2>&1) || { echo "$combine_out"; exit 1; }
+          echo "$combine_out"
+          combine_out_clean=$(echo "$combine_out" | sed 's/\x1B\[[0-9;]*m//g')
+
+          tree_size=$(du -h tree.aot | awk '{print $1}')
+
+          {
+            echo "## tree.aot creation (orchestrate-combine)"
+            echo
+            echo "- tree.aot: ${tree_size}"
+            echo
+            echo '```'
+            echo "$combine_out_clean"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          test -f tree.aot
+
+      # ── timed workload ───────────────────────────────────────────────────────
+
+      - name: Run timed workload
+        working-directory: tika-experiment
+        run: |
+          set -euo pipefail
+          chmod +x workload-timed.sh
+          wl_out=$(JAVA_NO_BIN="$TEMURIN_JAVA_HOME/bin/java" \
+                   JAVA_AOTCACHE_BIN="$TEMURIN_JAVA_HOME/bin/java" \
+                   JAVA_TREECACHE_BIN="$JAVA_HOME/bin/java" \
+                   ./workload-timed.sh 2>&1) || { echo "$wl_out"; exit 1; }
+          echo "$wl_out"
+          wl_out_clean=$(echo "$wl_out" | sed 's/\x1B\[[0-9;]*m//g')
+
+          single_size=$(du -ch single-*.aot | tail -1 | awk '{print $1}')
+          tree_size=$(du -h tree.aot | awk '{print $1}')
+
+          {
+            echo "## Timed workload results (no-AOT vs AOTCache vs TreeCache)"
+            echo
+            echo "- single-*.aot total: ${single_size}"
+            echo "- tree.aot: ${tree_size}"
+            echo
+            echo '```'
+            echo "$wl_out_clean"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Append LaTeX table rows to summary
+        working-directory: tika-experiment
+        run: |
+          {
+            echo "## LaTeX table rows (single=AOTCache, tree=TreeCache)"
+            echo
+            echo '```latex'
+            cat workload-tmp/latex-rows.tex
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: tika-tree-artifacts
+          path: |
+            tika-experiment/workload-tmp/
+            tika-experiment/single-text-pdf.aot
+            tika-experiment/single-text-docx.aot
+            tika-experiment/single-text-html.aot
+            tika-experiment/cli-text-pdf.aot
+            tika-experiment/cli-text-docx.aot
+            tika-experiment/cli-text-html.aot
+            tika-experiment/tree.aot
+            tika-experiment/tika/tika-core/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pdf-module/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/cache.aot
+          if-no-files-found: error

--- a/.github/workflows/tika-aot-cache.yml
+++ b/.github/workflows/tika-aot-cache.yml
@@ -49,9 +49,11 @@ jobs:
             ${{ runner.os }}-maven-tika-
             ${{ runner.os }}-maven-
 
-      - name: Build tika fat jar (skip tests)
+      - name: Install tika (skip tests)
         working-directory: tika-experiment/tika
         run: mvn install -DskipTests -q --no-transfer-progress
+
+      # ── component test-suite caches ──────────────────────────────────────────
 
       - name: Build tika-core cache (tree-merge)
         working-directory: tika-experiment/tika
@@ -180,9 +182,6 @@ jobs:
             tika-experiment/single-text-pdf.aot
             tika-experiment/single-text-docx.aot
             tika-experiment/single-text-html.aot
-            tika-experiment/cli-text-pdf.aot
-            tika-experiment/cli-text-docx.aot
-            tika-experiment/cli-text-html.aot
             tika-experiment/tree.aot
             tika-experiment/tika/tika-core/cache.aot
             tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pdf-module/cache.aot

--- a/.github/workflows/tika-aot-cache.yml
+++ b/.github/workflows/tika-aot-cache.yml
@@ -169,7 +169,7 @@ jobs:
           set -euo pipefail
           chmod +x create-single-aot.sh
           ./create-single-aot.sh
-          for op in text-pdf text-docx text-html; do
+          for op in text-pdf text-docx text-numbers; do
             test -f "single-${op}.aot"
           done
 
@@ -252,7 +252,7 @@ jobs:
             tika-experiment/workload-tmp/
             tika-experiment/single-text-pdf.aot
             tika-experiment/single-text-docx.aot
-            tika-experiment/single-text-html.aot
+            tika-experiment/single-text-numbers.aot
             tika-experiment/tree.aot
             tika-experiment/tika/tika-core/cache.aot
             tika-experiment/tika/tika-serialization/cache.aot

--- a/.gitmodules
+++ b/.gitmodules
@@ -109,3 +109,7 @@
 	path = opennlp-experiment/opennlp-deps/morfologik
 	url = git@github.com:algomaster99/morfologik-stemming.git
 	branch = aot-profiles
+[submodule "tika-experiment/tika"]
+	path = tika-experiment/tika
+	url = git@github.com:algomaster99/tika.git
+	branch = upstream-3.3.1

--- a/tika-experiment/create-single-aot.sh
+++ b/tika-experiment/create-single-aot.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -euo pipefail
+
+log()  { echo -e "\033[1;32m[$(date '+%H:%M:%S')] $*\033[0m"; }
+fail() { echo -e "\033[1;31mERROR: $*\033[0m" >&2; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+log "Java version:"
+java -version
+
+JAR="tika/tika-app/target/tika-app-3.3.1.jar"
+[[ -f "$JAR" ]] || fail "$JAR not found — run: cd tika && mvn install -DskipTests -q"
+
+DOCS_DIR="tika/tika-app/src/test/resources/test-data"
+
+OPS=(text-pdf text-docx text-html)
+
+_tika_args() {
+  case "$1" in
+    text-pdf)  echo "--text ${DOCS_DIR}/testPDF_childAttachments.pdf" ;;
+    text-docx) echo "--text ${DOCS_DIR}/test_recursive_embedded.docx" ;;
+    text-html) echo "--text ${DOCS_DIR}/testJsonMultipleInts.html" ;;
+  esac
+}
+
+for op in "${OPS[@]}"; do
+  single_aot="single-${op}.aot"
+  single_conf="single-${op}.aotconf"
+
+  if [[ -f "$single_aot" ]]; then
+    log "$single_aot already exists, skipping"
+    continue
+  fi
+
+  log "Recording single.aot for $op (step 1: AOTConfiguration)"
+  rm -f "$single_conf"
+  read -ra args <<< "$(_tika_args "$op")"
+  java -XX:AOTMode=record -XX:AOTConfiguration="$single_conf" \
+    -XX:+AOTClassLinking \
+    -jar "$JAR" "${args[@]}" >/dev/null 2>/dev/null || true
+  [[ -f "$single_conf" ]] || fail "AOTConfiguration not produced for $op"
+
+  log "Recording single.aot for $op (step 2: AOTCache)"
+  java -XX:AOTMode=create -XX:AOTConfiguration="$single_conf" \
+    -XX:AOTCache="$single_aot" \
+    -XX:+AOTClassLinking \
+    -jar "$JAR"
+  [[ -f "$single_aot" ]] || fail "$single_aot not created"
+  log "$single_aot created ($(du -sh "$single_aot" | cut -f1))"
+done

--- a/tika-experiment/create-single-aot.sh
+++ b/tika-experiment/create-single-aot.sh
@@ -15,13 +15,13 @@ JAR="tika/tika-app/target/tika-app-3.3.1.jar"
 
 DOCS_DIR="tika/tika-app/src/test/resources/test-data"
 
-OPS=(text-pdf text-docx text-numbers)
+OPS=(text-pdf text-docx text-archive)
 
 _tika_args() {
   case "$1" in
     text-pdf)     echo "--text ${DOCS_DIR}/testPDF_childAttachments.pdf" ;;
     text-docx)    echo "--text ${DOCS_DIR}/test_recursive_embedded.docx" ;;
-    text-numbers) echo "--text ${DOCS_DIR}/testMultipleSheets.numbers" ;;
+    text-archive) echo "--text ${DOCS_DIR}/test-documents.tgz" ;;
   esac
 }
 

--- a/tika-experiment/create-single-aot.sh
+++ b/tika-experiment/create-single-aot.sh
@@ -15,13 +15,13 @@ JAR="tika/tika-app/target/tika-app-3.3.1.jar"
 
 DOCS_DIR="tika/tika-app/src/test/resources/test-data"
 
-OPS=(text-pdf text-docx text-html)
+OPS=(text-pdf text-docx text-numbers)
 
 _tika_args() {
   case "$1" in
-    text-pdf)  echo "--text ${DOCS_DIR}/testPDF_childAttachments.pdf" ;;
-    text-docx) echo "--text ${DOCS_DIR}/test_recursive_embedded.docx" ;;
-    text-html) echo "--text ${DOCS_DIR}/testJsonMultipleInts.html" ;;
+    text-pdf)     echo "--text ${DOCS_DIR}/testPDF_childAttachments.pdf" ;;
+    text-docx)    echo "--text ${DOCS_DIR}/test_recursive_embedded.docx" ;;
+    text-numbers) echo "--text ${DOCS_DIR}/testMultipleSheets.numbers" ;;
   esac
 }
 

--- a/tika-experiment/orchestrate-combine.sh
+++ b/tika-experiment/orchestrate-combine.sh
@@ -10,80 +10,42 @@ cd "$SCRIPT_DIR"
 log "Java version:"
 java -version
 
+# Fat jar — used as the classpath for the merge step.
 JAR="tika/tika-app/target/tika-app-3.3.1.jar"
-[[ -f "$JAR" ]] || fail "$JAR not found — run: cd tika && mvn install -DskipTests -q"
+[[ -f "$JAR" ]] || fail "$JAR not found"
 
-DOCS_DIR="tika/tika-app/src/test/resources/test-data"
-
-# ── component test-suite caches (produced by mvn test -Ptree-merge) ───────────
-
+# Component test-suite caches (produced by mvn test -Ptree-merge in each module).
 TIKA_CORE_CACHE="tika/tika-core/cache.aot"
 TIKA_PDF_CACHE="tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pdf-module/cache.aot"
 TIKA_MSFT_CACHE="tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/cache.aot"
 
-for path in "$TIKA_CORE_CACHE" "$TIKA_PDF_CACHE" "$TIKA_MSFT_CACHE"; do
+CACHE_PATHS=(
+  "$TIKA_CORE_CACHE"
+  "$TIKA_PDF_CACHE"
+  "$TIKA_MSFT_CACHE"
+)
+
+for path in "${CACHE_PATHS[@]}"; do
   [[ -f "$path" ]] || fail "Missing cache: $path — run mvn test -Ptree-merge in that module"
 done
 
-CACHE_PATHS=("$TIKA_CORE_CACHE" "$TIKA_PDF_CACHE" "$TIKA_MSFT_CACHE")
-
-# ── CLI workload caches (covers TikaCLI and format-specific startup classes) ──
-
-OPS=(text-pdf text-docx text-html)
-
-_tika_args() {
-  case "$1" in
-    text-pdf)  echo "--text ${DOCS_DIR}/testPDF_childAttachments.pdf" ;;
-    text-docx) echo "--text ${DOCS_DIR}/test_recursive_embedded.docx" ;;
-    text-html) echo "--text ${DOCS_DIR}/testJsonMultipleInts.html" ;;
-  esac
-}
-
-CLI_CACHES=()
-for op in "${OPS[@]}"; do
-  cli_aot="cli-${op}.aot"
-  cli_conf="cli-${op}.aotconf"
-  if [[ -f "$cli_aot" ]]; then
-    log "$cli_aot already exists, reusing"
-  else
-    log "Recording CLI cache for $op (step 1: AOTConfiguration)"
-    rm -f "$cli_conf"
-    read -ra args <<< "$(_tika_args "$op")"
-    java -XX:AOTMode=record -XX:AOTConfiguration="$cli_conf" \
-      -XX:+AOTClassLinking \
-      -jar "$JAR" "${args[@]}" >/dev/null 2>/dev/null || true
-    [[ -f "$cli_conf" ]] || fail "AOTConfiguration not produced for $op"
-
-    log "Recording CLI cache for $op (step 2: AOTCache)"
-    java -XX:AOTMode=create -XX:AOTConfiguration="$cli_conf" \
-      -XX:AOTCache="$cli_aot" \
-      -XX:+AOTClassLinking \
-      -jar "$JAR"
-    [[ -f "$cli_aot" ]] || fail "$cli_aot not created"
-    log "$cli_aot created ($(du -sh "$cli_aot" | cut -f1))"
-  fi
-  CLI_CACHES+=("$cli_aot")
-done
-
-# ── merge all caches → tree.aot ───────────────────────────────────────────────
-
-ALL_CACHES=("${CACHE_PATHS[@]}" "${CLI_CACHES[@]}")
-BASE_AOT="${ALL_CACHES[0]}"
-MERGE_INPUTS="$(IFS=:; echo "${ALL_CACHES[*]}")"
+BASE_AOT="${CACHE_PATHS[0]}"
+MERGE_INPUTS="$(IFS=:; echo "${CACHE_PATHS[*]}")"
 OUTPUT_AOT="tree.aot"
 
 rm -f "$OUTPUT_AOT"
 
-log "Merging ${#ALL_CACHES[@]} caches → $OUTPUT_AOT"
+log "Merging ${#CACHE_PATHS[@]} caches → $OUTPUT_AOT"
 java \
   -Xlog:aot=info \
   -Xlog:aot+map=trace,aot+map+oops=trace,aot=warning:file=aot.map:none:filesize=0 \
+  -Djava.awt.headless=true \
   -XX:AOTMode=merge \
   -XX:AOTCache="$BASE_AOT" \
   -XX:AOTMergeInputs="$MERGE_INPUTS" \
   -XX:AOTCacheOutput="$OUTPUT_AOT" \
-  -jar "$JAR" \
-  --help >/dev/null 2>&1 || true
+  -cp "$JAR" \
+  -version
 
 [[ -f "$OUTPUT_AOT" ]] || fail "tree.aot was not created"
 log "$OUTPUT_AOT created ($(du -sh "$OUTPUT_AOT" | cut -f1))"

--- a/tika-experiment/orchestrate-combine.sh
+++ b/tika-experiment/orchestrate-combine.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+set -euo pipefail
+
+log()  { echo -e "\033[1;32m[$(date '+%H:%M:%S')] $*\033[0m"; }
+fail() { echo -e "\033[1;31mERROR: $*\033[0m" >&2; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+log "Java version:"
+java -version
+
+JAR="tika/tika-app/target/tika-app-3.3.1.jar"
+[[ -f "$JAR" ]] || fail "$JAR not found — run: cd tika && mvn install -DskipTests -q"
+
+DOCS_DIR="tika/tika-app/src/test/resources/test-data"
+
+# ── component test-suite caches (produced by mvn test -Ptree-merge) ───────────
+
+TIKA_CORE_CACHE="tika/tika-core/cache.aot"
+TIKA_PDF_CACHE="tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pdf-module/cache.aot"
+TIKA_MSFT_CACHE="tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/cache.aot"
+
+for path in "$TIKA_CORE_CACHE" "$TIKA_PDF_CACHE" "$TIKA_MSFT_CACHE"; do
+  [[ -f "$path" ]] || fail "Missing cache: $path — run mvn test -Ptree-merge in that module"
+done
+
+CACHE_PATHS=("$TIKA_CORE_CACHE" "$TIKA_PDF_CACHE" "$TIKA_MSFT_CACHE")
+
+# ── CLI workload caches (covers TikaCLI and format-specific startup classes) ──
+
+OPS=(text-pdf text-docx text-html)
+
+_tika_args() {
+  case "$1" in
+    text-pdf)  echo "--text ${DOCS_DIR}/testPDF_childAttachments.pdf" ;;
+    text-docx) echo "--text ${DOCS_DIR}/test_recursive_embedded.docx" ;;
+    text-html) echo "--text ${DOCS_DIR}/testJsonMultipleInts.html" ;;
+  esac
+}
+
+CLI_CACHES=()
+for op in "${OPS[@]}"; do
+  cli_aot="cli-${op}.aot"
+  cli_conf="cli-${op}.aotconf"
+  if [[ -f "$cli_aot" ]]; then
+    log "$cli_aot already exists, reusing"
+  else
+    log "Recording CLI cache for $op (step 1: AOTConfiguration)"
+    rm -f "$cli_conf"
+    read -ra args <<< "$(_tika_args "$op")"
+    java -XX:AOTMode=record -XX:AOTConfiguration="$cli_conf" \
+      -XX:+AOTClassLinking \
+      -jar "$JAR" "${args[@]}" >/dev/null 2>/dev/null || true
+    [[ -f "$cli_conf" ]] || fail "AOTConfiguration not produced for $op"
+
+    log "Recording CLI cache for $op (step 2: AOTCache)"
+    java -XX:AOTMode=create -XX:AOTConfiguration="$cli_conf" \
+      -XX:AOTCache="$cli_aot" \
+      -XX:+AOTClassLinking \
+      -jar "$JAR"
+    [[ -f "$cli_aot" ]] || fail "$cli_aot not created"
+    log "$cli_aot created ($(du -sh "$cli_aot" | cut -f1))"
+  fi
+  CLI_CACHES+=("$cli_aot")
+done
+
+# ── merge all caches → tree.aot ───────────────────────────────────────────────
+
+ALL_CACHES=("${CACHE_PATHS[@]}" "${CLI_CACHES[@]}")
+BASE_AOT="${ALL_CACHES[0]}"
+MERGE_INPUTS="$(IFS=:; echo "${ALL_CACHES[*]}")"
+OUTPUT_AOT="tree.aot"
+
+rm -f "$OUTPUT_AOT"
+
+log "Merging ${#ALL_CACHES[@]} caches → $OUTPUT_AOT"
+java \
+  -Xlog:aot=info \
+  -Xlog:aot+map=trace,aot+map+oops=trace,aot=warning:file=aot.map:none:filesize=0 \
+  -XX:AOTMode=merge \
+  -XX:AOTCache="$BASE_AOT" \
+  -XX:AOTMergeInputs="$MERGE_INPUTS" \
+  -XX:AOTCacheOutput="$OUTPUT_AOT" \
+  -jar "$JAR" \
+  --help >/dev/null 2>&1 || true
+
+[[ -f "$OUTPUT_AOT" ]] || fail "tree.aot was not created"
+log "$OUTPUT_AOT created ($(du -sh "$OUTPUT_AOT" | cut -f1))"

--- a/tika-experiment/orchestrate-combine.sh
+++ b/tika-experiment/orchestrate-combine.sh
@@ -14,15 +14,21 @@ java -version
 JAR="tika/tika-app/target/tika-app-3.3.1.jar"
 [[ -f "$JAR" ]] || fail "$JAR not found"
 
-# Component test-suite caches (produced by mvn test -Ptree-merge in each module).
-TIKA_CORE_CACHE="tika/tika-core/cache.aot"
-TIKA_PDF_CACHE="tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pdf-module/cache.aot"
-TIKA_MSFT_CACHE="tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/cache.aot"
+TIKA_PARSERS="tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules"
 
+# Component test-suite caches (produced by mvn test -Ptree-merge in each module).
 CACHE_PATHS=(
-  "$TIKA_CORE_CACHE"
-  "$TIKA_PDF_CACHE"
-  "$TIKA_MSFT_CACHE"
+  "tika/tika-core/cache.aot"
+  "tika/tika-serialization/cache.aot"
+  "${TIKA_PARSERS}/tika-parser-pdf-module/cache.aot"
+  "${TIKA_PARSERS}/tika-parser-microsoft-module/cache.aot"
+  "${TIKA_PARSERS}/tika-parser-image-module/cache.aot"
+  "${TIKA_PARSERS}/tika-parser-pkg-module/cache.aot"
+  "${TIKA_PARSERS}/tika-parser-code-module/cache.aot"
+  "${TIKA_PARSERS}/tika-parser-audiovideo-module/cache.aot"
+  "${TIKA_PARSERS}/tika-parser-miscoffice-module/cache.aot"
+  "${TIKA_PARSERS}/tika-parser-apple-module/cache.aot"
+  "${TIKA_PARSERS}/tika-parser-webarchive-module/cache.aot"
 )
 
 for path in "${CACHE_PATHS[@]}"; do

--- a/tika-experiment/orchestrate-combine.sh
+++ b/tika-experiment/orchestrate-combine.sh
@@ -29,6 +29,11 @@ CACHE_PATHS=(
   "${TIKA_PARSERS}/tika-parser-miscoffice-module/cache.aot"
   "${TIKA_PARSERS}/tika-parser-apple-module/cache.aot"
   "${TIKA_PARSERS}/tika-parser-webarchive-module/cache.aot"
+  "${TIKA_PARSERS}/tika-parser-crypto-module/cache.aot"
+  "${TIKA_PARSERS}/tika-parser-cad-module/cache.aot"
+  "${TIKA_PARSERS}/tika-parser-font-module/cache.aot"
+  "${TIKA_PARSERS}/tika-parser-news-module/cache.aot"
+  "tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-package/cache.aot"
 )
 
 for path in "${CACHE_PATHS[@]}"; do

--- a/tika-experiment/workload-timed.sh
+++ b/tika-experiment/workload-timed.sh
@@ -18,7 +18,7 @@ JAVA_NO_BIN="${JAVA_NO_BIN:-java}"
 JAVA_AOTCACHE_BIN="${JAVA_AOTCACHE_BIN:-java}"
 JAVA_TREECACHE_BIN="${JAVA_TREECACHE_BIN:-java}"
 
-OPS=(text-pdf text-docx text-numbers)
+OPS=(text-pdf text-docx text-archive)
 
 mkdir -p "$WORK_DIR"
 
@@ -32,7 +32,7 @@ _tika_args() {
   case "$1" in
     text-pdf)     echo "--text ${DOCS_DIR}/testPDF_childAttachments.pdf" ;;
     text-docx)    echo "--text ${DOCS_DIR}/test_recursive_embedded.docx" ;;
-    text-numbers) echo "--text ${DOCS_DIR}/testMultipleSheets.numbers" ;;
+    text-archive) echo "--text ${DOCS_DIR}/test-documents.tgz" ;;
   esac
 }
 
@@ -174,7 +174,7 @@ _print_latex_rows() {
   echo "\\midrule" >> "$tex_file"
 }
 
-_print_latex_rows "Apache Tika (PDF / DOCX / Numbers)"
+_print_latex_rows "Apache Tika (PDF / DOCX / Archive)"
 
 # ── class-load breakdown ──────────────────────────────────────────────────────
 

--- a/tika-experiment/workload-timed.sh
+++ b/tika-experiment/workload-timed.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+set -euo pipefail
+
+log()  { echo -e "\033[1;32m[$(date '+%H:%M:%S')] $*\033[0m"; }
+sep()  { echo -e "\033[0;90m  $(printf '─%.0s' {1..60})\033[0m"; }
+fail() { echo -e "\033[1;31mERROR: $*\033[0m" >&2; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+JAR="tika/tika-app/target/tika-app-3.3.1.jar"
+DOCS_DIR="tika/tika-app/src/test/resources/test-data"
+TREECACHE_AOT="tree.aot"
+WORK_DIR="workload-tmp"
+
+RUNS="${RUNS:-30}"
+JAVA_NO_BIN="${JAVA_NO_BIN:-java}"
+JAVA_AOTCACHE_BIN="${JAVA_AOTCACHE_BIN:-java}"
+JAVA_TREECACHE_BIN="${JAVA_TREECACHE_BIN:-java}"
+
+OPS=(text-pdf text-docx text-html)
+
+mkdir -p "$WORK_DIR"
+
+[[ -f "$JAR" ]] || fail "$JAR not found"
+for _op in "${OPS[@]}"; do
+  [[ -f "single-${_op}.aot" ]] || fail "single-${_op}.aot not found — run ./create-single-aot.sh first"
+done
+[[ -f "$TREECACHE_AOT" ]] || fail "tree.aot not found — run ./orchestrate-combine.sh first"
+
+_tika_args() {
+  case "$1" in
+    text-pdf)  echo "--text ${DOCS_DIR}/testPDF_childAttachments.pdf" ;;
+    text-docx) echo "--text ${DOCS_DIR}/test_recursive_embedded.docx" ;;
+    text-html) echo "--text ${DOCS_DIR}/testJsonMultipleInts.html" ;;
+  esac
+}
+
+log "Java binaries:"
+printf "  no-AOT:    %s\n" "$JAVA_NO_BIN";       "$JAVA_NO_BIN"       -version 2>&1 | head -1
+printf "  AOTCache:  %s\n" "$JAVA_AOTCACHE_BIN"; "$JAVA_AOTCACHE_BIN" -version 2>&1 | head -1
+printf "  TreeCache: %s\n" "$JAVA_TREECACHE_BIN"; "$JAVA_TREECACHE_BIN" -version 2>&1 | head -1
+echo
+
+# ── timing helpers ────────────────────────────────────────────────────────────
+
+ms() { date +%s%N | awk '{printf "%.1f", $1/1000000}'; }
+
+declare -A _samples
+
+_update() { _samples[$1]="${_samples[$1]:-} $2"; }
+
+_mean() {
+  local s="${_samples[$1]:-}"
+  [[ -z "$s" ]] && { echo "n/a"; return; }
+  printf "%s\n" $s | awk '{sum+=$1;n++} END{if(!n)print "n/a"; else printf "%.1f",sum/n}'
+}
+
+_stddev() {
+  local s="${_samples[$1]:-}"
+  [[ -z "$s" ]] && { echo "n/a"; return; }
+  printf "%s\n" $s | awk '{sum+=$1;sumsq+=$1*$1;n++} END{if(n<2)print "n/a"; else printf "%.1f",sqrt((sumsq-sum*sum/n)/(n-1))}'
+}
+
+_measure() {
+  local key="$1" op="$2" java_bin="$3"
+  shift 3
+  local errfile="$WORK_DIR/${key//|/-}.err"
+  local t0 t1 rc=0
+  read -ra args <<< "$(_tika_args "$op")"
+  t0=$(ms)
+  "$java_bin" "$@" -jar "$JAR" "${args[@]}" >/dev/null 2>"$errfile" || rc=$?
+  t1=$(ms)
+  if (( rc != 0 )); then
+    echo "  WARN: key=$key exited $rc — see $errfile" >&2
+    return
+  fi
+  _update "$key" "$(awk "BEGIN{printf \"%.1f\",$t1-$t0}")"
+}
+
+# ── main loop ─────────────────────────────────────────────────────────────────
+
+log "Running $RUNS iterations × ${#OPS[@]} ops (cross-workload)"
+sep
+
+for run in $(seq 1 "$RUNS"); do
+  printf "  run %2d/%d\n" "$run" "$RUNS"
+  for op in "${OPS[@]}"; do
+    _measure "${op}|no"        "$op" "$JAVA_NO_BIN"
+    _measure "${op}|TreeCache" "$op" "$JAVA_TREECACHE_BIN" \
+      -XX:AOTCache="$TREECACHE_AOT" -XX:+AOTClassLinking
+  done
+  for train_op in "${OPS[@]}"; do
+    for test_op in "${OPS[@]}"; do
+      [[ "$test_op" == "$train_op" ]] && continue
+      _measure "${train_op}|${test_op}|aotcache" "$test_op" "$JAVA_AOTCACHE_BIN" \
+        -XX:AOTCache="single-${train_op}.aot" -XX:+AOTClassLinking
+    done
+  done
+done
+
+# ── results ───────────────────────────────────────────────────────────────────
+
+_test_mean_aotcache() {
+  local test_op="$1" sum=0 n=0 train_op m
+  for train_op in "${OPS[@]}"; do
+    [[ "$train_op" == "$test_op" ]] && continue
+    m=$(_mean "${train_op}|${test_op}|aotcache")
+    [[ "$m" == "n/a" ]] && continue
+    sum=$(awk "BEGIN{printf \"%.4f\",$sum+$m}")
+    n=$(( n + 1 ))
+  done
+  [[ $n -eq 0 ]] && { echo "n/a"; return; }
+  awk -v s="$sum" -v n="$n" 'BEGIN{printf "%.1f",s/n}'
+}
+
+_test_stddev_aotcache() {
+  local test_op="$1" all="" train_op
+  for train_op in "${OPS[@]}"; do
+    [[ "$train_op" == "$test_op" ]] && continue
+    all="$all ${_samples[${train_op}|${test_op}|aotcache]:-}"
+  done
+  printf "%s\n" $all | awk '{sum+=$1;sumsq+=$1*$1;n++} END{if(n<2)print "n/a"; else printf "%.1f",sqrt((sumsq-sum*sum/n)/(n-1))}'
+}
+
+echo
+log "Per-workload timing over $RUNS runs (ms) — AOTCache uses caches trained on other ops"
+sep
+printf "  %-20s | %18s | %20s %12s | %20s %12s\n" \
+  "Workload" "no (mean±SD)" "aotcache (mean±SD)" "su-aotcache" "TreeCache (mean±SD)" "su-TreeCache"
+sep
+for op in "${OPS[@]}"; do
+  m_no=$(_mean "${op}|no")
+  m_mono=$(_test_mean_aotcache "$op")
+  m_tree=$(_mean "${op}|TreeCache")
+  sd_no=$(_stddev "${op}|no")
+  sd_mono=$(_test_stddev_aotcache "$op")
+  sd_tree=$(_stddev "${op}|TreeCache")
+  su_mono=$(awk -v b="$m_no" -v a="$m_mono" 'BEGIN{if(a+0==0){print "n/a"}else{printf "%.2fx",b/a}}')
+  su_tree=$(awk -v b="$m_no" -v a="$m_tree" 'BEGIN{if(a+0==0){print "n/a"}else{printf "%.2fx",b/a}}')
+  printf "  %-20s | %18s | %20s %12s | %20s %12s\n" \
+    "$op" "${m_no}±${sd_no}" "${m_mono}±${sd_mono}" "$su_mono" "${m_tree}±${sd_tree}" "$su_tree"
+done
+
+# ── LaTeX rows ────────────────────────────────────────────────────────────────
+
+_print_latex_rows() {
+  local project="$1" n="${#OPS[@]}" tex_file="$WORK_DIR/latex-rows.tex"
+  local sum_su_mono=0 sum_su_tree=0 cnt_mono=0 cnt_tree=0
+  echo "\\multirow{$(( n + 1 ))}{*}{${project}}" > "$tex_file"
+  for op in "${OPS[@]}"; do
+    local m_no m_mono m_tree sd_no sd_mono sd_tree su_mono su_tree fmt_mono fmt_tree
+    m_no=$(_mean "${op}|no");          sd_no=$(_stddev "${op}|no")
+    m_mono=$(_test_mean_aotcache "$op"); sd_mono=$(_test_stddev_aotcache "$op")
+    m_tree=$(_mean "${op}|TreeCache"); sd_tree=$(_stddev "${op}|TreeCache")
+    su_mono=$(awk -v b="$m_no" -v a="$m_mono" 'BEGIN{if(a+0==0){print "n/a"}else{printf "%.2f",b/a}}')
+    su_tree=$(awk -v b="$m_no" -v a="$m_tree" 'BEGIN{if(a+0==0){print "n/a"}else{printf "%.2f",b/a}}')
+    if [[ "$su_mono" != "n/a" ]]; then
+      sum_su_mono=$(awk "BEGIN{printf \"%.4f\",$sum_su_mono+$su_mono}"); cnt_mono=$(( cnt_mono+1 ))
+    fi
+    if [[ "$su_tree" != "n/a" ]]; then
+      sum_su_tree=$(awk "BEGIN{printf \"%.4f\",$sum_su_tree+$su_tree}"); cnt_tree=$(( cnt_tree+1 ))
+    fi
+    fmt_mono=$(awk -v a="$su_mono" -v b="$su_tree" 'BEGIN{if(a+0>b+0) print "\\textbf{"a"x}"; else print a"x"}')
+    fmt_tree=$(awk -v a="$su_mono" -v b="$su_tree" 'BEGIN{if(b+0>a+0) print "\\textbf{"b"x}"; else print b"x"}')
+    echo "  & ${op} & \$${m_no} \pm ${sd_no}\$ & \$${m_mono} \pm ${sd_mono}\$ & ${fmt_mono} & \$${m_tree} \pm ${sd_tree}\$ & ${fmt_tree} \\\\" >> "$tex_file"
+  done
+  local avg_mono avg_tree fmt_avg_mono fmt_avg_tree
+  avg_mono=$(awk -v s="$sum_su_mono" -v c="$cnt_mono" 'BEGIN{if(c==0)print "n/a"; else printf "%.2f",s/c}')
+  avg_tree=$(awk -v s="$sum_su_tree"  -v c="$cnt_tree"  'BEGIN{if(c==0)print "n/a"; else printf "%.2f",s/c}')
+  fmt_avg_mono=$(awk -v a="$avg_mono" -v b="$avg_tree" 'BEGIN{if(a+0>b+0) print "\\textbf{"a"x}"; else print a"x"}')
+  fmt_avg_tree=$(awk -v a="$avg_mono" -v b="$avg_tree" 'BEGIN{if(b+0>a+0) print "\\textbf{"b"x}"; else print b"x"}')
+  echo "  & \\textit{Average} & & & ${fmt_avg_mono} & & ${fmt_avg_tree} \\\\" >> "$tex_file"
+  echo "\\midrule" >> "$tex_file"
+}
+
+_print_latex_rows "Apache Tika"
+
+# ── class-load breakdown ──────────────────────────────────────────────────────
+
+_classload_row() {
+  local op="$1" mode="$2"
+  local logfile="$WORK_DIR/cl-${op}-${mode}.log"
+  local rc=0
+  read -ra args <<< "$(_tika_args "$op")"
+  case "$mode" in
+    no)
+      "$JAVA_NO_BIN" \
+        -Xlog:class+load:file="$logfile" \
+        -jar "$JAR" "${args[@]}" >/dev/null 2>&1 || rc=$? ;;
+    AOTCache)
+      "$JAVA_AOTCACHE_BIN" \
+        -XX:AOTCache="single-${op}.aot" -XX:+AOTClassLinking \
+        -Xlog:class+load:file="$logfile" \
+        -jar "$JAR" "${args[@]}" >/dev/null 2>&1 || rc=$? ;;
+    TreeCache)
+      "$JAVA_TREECACHE_BIN" \
+        -XX:AOTCache="$TREECACHE_AOT" -XX:+AOTClassLinking \
+        -Xlog:class+load:file="$logfile" \
+        -jar "$JAR" "${args[@]}" >/dev/null 2>&1 || rc=$? ;;
+  esac
+  if (( rc != 0 )); then
+    printf "  %-22s | %-9s | %8s | %8s\n" "$op" "$mode" "n/a" "n/a"
+    return
+  fi
+  printf "  %-22s | %-9s | %8s | %8s\n" "$op" "$mode" \
+    "$(awk '/source: file:/{c++} END{print c+0}' "$logfile")" \
+    "$(awk '/source: shared objects/{c++} END{print c+0}' "$logfile")"
+}
+
+echo
+log "Class-load source breakdown (AOTCache uses same-workload cache)"
+sep
+printf "  %-22s | %-9s | %8s | %8s\n" "Operation" "Mode" "file:" "shared"
+sep
+for op in "${OPS[@]}"; do
+  for mode in no AOTCache TreeCache; do
+    _classload_row "$op" "$mode"
+  done
+  sep
+done

--- a/tika-experiment/workload-timed.sh
+++ b/tika-experiment/workload-timed.sh
@@ -18,7 +18,7 @@ JAVA_NO_BIN="${JAVA_NO_BIN:-java}"
 JAVA_AOTCACHE_BIN="${JAVA_AOTCACHE_BIN:-java}"
 JAVA_TREECACHE_BIN="${JAVA_TREECACHE_BIN:-java}"
 
-OPS=(text-pdf text-docx text-html)
+OPS=(text-pdf text-docx text-numbers)
 
 mkdir -p "$WORK_DIR"
 
@@ -30,9 +30,9 @@ done
 
 _tika_args() {
   case "$1" in
-    text-pdf)  echo "--text ${DOCS_DIR}/testPDF_childAttachments.pdf" ;;
-    text-docx) echo "--text ${DOCS_DIR}/test_recursive_embedded.docx" ;;
-    text-html) echo "--text ${DOCS_DIR}/testJsonMultipleInts.html" ;;
+    text-pdf)     echo "--text ${DOCS_DIR}/testPDF_childAttachments.pdf" ;;
+    text-docx)    echo "--text ${DOCS_DIR}/test_recursive_embedded.docx" ;;
+    text-numbers) echo "--text ${DOCS_DIR}/testMultipleSheets.numbers" ;;
   esac
 }
 
@@ -174,7 +174,7 @@ _print_latex_rows() {
   echo "\\midrule" >> "$tex_file"
 }
 
-_print_latex_rows "Apache Tika"
+_print_latex_rows "Apache Tika (PDF / DOCX / Numbers)"
 
 # ── class-load breakdown ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Adds `tika-experiment/` with tree-merge profiles on three Tika modules: `tika-core`, `tika-parser-pdf-module`, `tika-parser-microsoft-module`
- Submodule `algomaster99/tika@upstream-3.3.1` carries the surefire `tree-merge` profile in each module
- `orchestrate-combine.sh` merges 3 component test-suite caches + 3 CLI workload caches → `tree.aot`
- Workloads (`text-pdf`, `text-docx`, `text-html`) load genuinely distinct class stacks (PDFBox, Apache POI, HTML parser), making this a strong test of hypothesis B (tree cache generalises across format-specific workloads)
- Deletes the certificate-ripper experiment (Netty/JDK 25 Unsafe incompatibility made results unreliable)

## Test plan

- [ ] CI `tika-aot-cache` job passes — all three `mvn test -Ptree-merge` steps produce `cache.aot`
- [ ] `tree.aot` is created successfully from 6 merged caches
- [ ] `single-*.aot` files are produced for all three workloads
- [ ] Workload timing table and LaTeX rows appear in job summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)