### PR TITLE
Add AOT cache composition reporting to Tika experiment

### DIFF
--- a/.github/workflows/tika-aot-cache.yml
+++ b/.github/workflows/tika-aot-cache.yml
@@ -289,6 +289,18 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: AOT cache composition (sizes + class counts)
+        working-directory: tika-experiment
+        run: |
+          latex_out=$(python3 generate-latex-table.py)
+          {
+            echo "## AOT cache composition (size, JDK classes, app classes)"
+            echo
+            echo '```latex'
+            echo "$latex_out"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
@@ -299,20 +311,37 @@ jobs:
             tika-experiment/single-text-docx.aot
             tika-experiment/single-text-archive.aot
             tika-experiment/tree.aot
+            tika-experiment/aot.map
             tika-experiment/tika/tika-core/cache.aot
+            tika-experiment/tika/tika-core/aot.map
             tika-experiment/tika/tika-serialization/cache.aot
+            tika-experiment/tika/tika-serialization/aot.map
             tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pdf-module/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pdf-module/aot.map
             tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/aot.map
             tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-image-module/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-image-module/aot.map
             tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pkg-module/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pkg-module/aot.map
             tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-code-module/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-code-module/aot.map
             tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-audiovideo-module/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-audiovideo-module/aot.map
             tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-miscoffice-module/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-miscoffice-module/aot.map
             tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-apple-module/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-apple-module/aot.map
             tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-webarchive-module/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-webarchive-module/aot.map
             tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-crypto-module/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-crypto-module/aot.map
             tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-cad-module/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-cad-module/aot.map
             tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-font-module/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-font-module/aot.map
             tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-news-module/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-news-module/aot.map
             tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-package/cache.aot
+            tika-experiment/tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-package/aot.map
           if-no-files-found: error

--- a/tika-experiment/generate-latex-table.py
+++ b/tika-experiment/generate-latex-table.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Print LaTeX table rows (Size, Classes, App%) for all Apache Tika AOT caches.
+
+App% = fraction of archived classes whose top-level package is not JDK-internal
+(i.e. not java/jdk/sun/javax).  Run from anywhere — paths are relative to this file.
+"""
+import re, os, sys, argparse
+
+PRIMITIVES = frozenset('ZBCSIFJD')
+JDK = {'java', 'jdk', 'sun', 'javax', 'com.sun'} | PRIMITIVES
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+_P = 'tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules'
+
+ROWS = [
+    ('tika-core',                  'tika/tika-core/cache.aot',                                    'tika/tika-core/aot.map'),
+    ('tika-serialization',         'tika/tika-serialization/cache.aot',                           'tika/tika-serialization/aot.map'),
+    ('tika-parser-pdf',            f'{_P}/tika-parser-pdf-module/cache.aot',                      f'{_P}/tika-parser-pdf-module/aot.map'),
+    ('tika-parser-microsoft',      f'{_P}/tika-parser-microsoft-module/cache.aot',                f'{_P}/tika-parser-microsoft-module/aot.map'),
+    ('tika-parser-image',          f'{_P}/tika-parser-image-module/cache.aot',                    f'{_P}/tika-parser-image-module/aot.map'),
+    ('tika-parser-pkg',            f'{_P}/tika-parser-pkg-module/cache.aot',                      f'{_P}/tika-parser-pkg-module/aot.map'),
+    ('tika-parser-code',           f'{_P}/tika-parser-code-module/cache.aot',                     f'{_P}/tika-parser-code-module/aot.map'),
+    ('tika-parser-audiovideo',     f'{_P}/tika-parser-audiovideo-module/cache.aot',               f'{_P}/tika-parser-audiovideo-module/aot.map'),
+    ('tika-parser-miscoffice',     f'{_P}/tika-parser-miscoffice-module/cache.aot',               f'{_P}/tika-parser-miscoffice-module/aot.map'),
+    ('tika-parser-apple',          f'{_P}/tika-parser-apple-module/cache.aot',                    f'{_P}/tika-parser-apple-module/aot.map'),
+    ('tika-parser-webarchive',     f'{_P}/tika-parser-webarchive-module/cache.aot',               f'{_P}/tika-parser-webarchive-module/aot.map'),
+    ('tika-parser-crypto',         f'{_P}/tika-parser-crypto-module/cache.aot',                   f'{_P}/tika-parser-crypto-module/aot.map'),
+    ('tika-parser-cad',            f'{_P}/tika-parser-cad-module/cache.aot',                      f'{_P}/tika-parser-cad-module/aot.map'),
+    ('tika-parser-font',           f'{_P}/tika-parser-font-module/cache.aot',                     f'{_P}/tika-parser-font-module/aot.map'),
+    ('tika-parser-news',           f'{_P}/tika-parser-news-module/cache.aot',                     f'{_P}/tika-parser-news-module/aot.map'),
+    ('tika-parsers-std-pkg',       'tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-package/cache.aot',
+                                   'tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-package/aot.map'),
+]
+TREE = ('tree.aot', 'aot.map')
+
+
+def get_pkg(class_name):
+    name = class_name.strip()
+    while name.startswith('['):
+        name = name[1:]
+    if name.startswith('L') and name.endswith(';'):
+        name = name[1:-1]
+    if not name:
+        return None
+    if '.' not in name:
+        return name if name in PRIMITIVES else None
+    parts = name.split('.')
+    if parts[0] == 'com' and len(parts) >= 2:
+        return parts[0] + '.' + parts[1]
+    return parts[0]
+
+
+def analyze(cache_path, map_path, debug=False):
+    size_mb = os.path.getsize(os.path.join(HERE, cache_path)) / 1024 / 1024
+    with open(os.path.join(HERE, map_path), 'rb') as f:
+        data = f.read().decode('utf-8', errors='replace')
+    jdk_cls = app_cls = 0
+    for line in data.splitlines():
+        m = re.match(r'.*@@ Class\s+\d+\s+(\S+)', line)
+        if not m:
+            continue
+        raw = m.group(1)
+        pkg = get_pkg(raw)
+        if pkg is None:
+            if debug:
+                print(f'  SKIP    {raw}')
+            continue
+        if pkg in JDK:
+            jdk_cls += 1
+            if debug:
+                print(f'  JDK     {raw}')
+        else:
+            app_cls += 1
+            if debug:
+                print(f'  APP     {raw}')
+    return size_mb, jdk_cls, app_cls
+
+
+def fmt_row(label, size_mb, jdk_cls, app_cls, bold_size=False):
+    size_str = f'{size_mb:.0f}\\,MB'
+    if bold_size:
+        size_str = f'\\textbf{{{size_str}}}'
+    total = jdk_cls + app_cls
+    jdk_pct = jdk_cls / total * 100 if total else 0
+    app_pct = app_cls / total * 100 if total else 0
+    jdk_str = f'{jdk_cls:>6,} ({jdk_pct:>5.1f}\\%)'
+    app_str = f'{app_cls:>6,} ({app_pct:>5.1f}\\%)'
+    return f'{label:<26} & {size_str} & {jdk_str} & {app_str} \\\\'
+
+
+parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+parser.add_argument('--debug', metavar='MAP_FILE', nargs='?', const='',
+                    help='dump every classified class; omit MAP_FILE to list known maps')
+args = parser.parse_args()
+
+if args.debug is not None:
+    all_rows = [(c, m) for _, c, m in ROWS + [('tree.aot', *TREE)]]
+    if args.debug == '':
+        print('Known map paths:')
+        for _, m in all_rows:
+            print(f'  {m}')
+        sys.exit(0)
+    match = next(((c, m) for c, m in all_rows if m == args.debug or m.endswith(args.debug)), None)
+    if match is None:
+        parser.error(f'no row with map path matching {args.debug!r}\nKnown:\n' +
+                     '\n'.join(f'  {m}' for _, m in all_rows))
+    cache_path, map_path = match
+    print(f'cache: {cache_path}')
+    print(f'map:   {map_path}')
+    size_mb, jdk_cls, app_cls = analyze(cache_path, map_path, debug=True)
+    total = jdk_cls + app_cls
+    print(f'\n=> {total} classes: {jdk_cls} JDK ({jdk_cls/total*100:.1f}%), {app_cls} app ({app_cls/total*100:.1f}%), {size_mb:.2f} MB')
+    sys.exit(0)
+
+missing = [p for _, c, m in ROWS + [('', *TREE)] for p in (c, m)
+           if not os.path.exists(os.path.join(HERE, p))]
+if missing:
+    print('ERROR: missing files:\n  ' + '\n  '.join(missing), file=sys.stderr)
+    sys.exit(1)
+
+print(r'\multicolumn{4}{@{}l}{\textit{tika}} \\')
+for label, cache, mapf in ROWS:
+    print(fmt_row(label, *analyze(cache, mapf)))
+print(fmt_row(r'\toolname', *analyze(*TREE), bold_size=True))
+print(r'\midrule')


### PR DESCRIPTION
## Summary

Adds AOT cache composition reporting to the Apache Tika experiment, and fixes a broken submodule pointer that caused CI to fail with `upload-pack: not our ref`.

## Changes

- **Fix submodule pointer**: The `tika-experiment/tika` submodule was pointing to commit `0d6ed87a9` which had not been pushed to the remote fork, causing CI (`tree-combine`) to fail when fetching. The commit is now pushed to `algomaster99/tika` on `upstream-3.3.1`.
- **Add CI workflow** (`.github/workflows/tika-aot-cache.yml`): Triggers the AOT cache composition report job for the Tika experiment.
- **Add `generate-latex-table.py`**: Script that parses `aot.map` logs (written by the updated surefire `argLine` `-Xlog:aot+map=trace`) to report class-count composition (JDK vs app classes) alongside cache file sizes for all 16 tree-merge profiles.

## Testing

CI should pass the `tree-combine` step that previously failed with:
```
Fetched in submodule path 'tika-experiment/tika', but it did not contain 0d6ed87a9930596b7759f90dea5687a0e0154803
remote error: upload-pack: not our ref 0d6ed87a9930596b7759f90dea5687a0e0154803
```

## Checklist
- [x] Submodule commit pushed to remote before branch creation
- [x] No breaking changes to existing experiments