### PR TITLE
Limit CI to paper workflows; add biojava class-load breakdown table

### DIFF
--- a/.github/workflows/batik-iterative-aot.yml
+++ b/.github/workflows/batik-iterative-aot.yml
@@ -1,9 +1,6 @@
 name: Batik Iterative AOT Cache
 
 on:
-  push:
-    branches: [main]
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/biojava-aot-cache.yml
+++ b/.github/workflows/biojava-aot-cache.yml
@@ -220,6 +220,17 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Append class-load breakdown table to summary
+        working-directory: biojava-experiment
+        run: |
+          {
+            echo "## Class-load breakdown (Arch-JDK / Arch-APP / Classpath / Gen.)"
+            echo
+            echo '```latex'
+            python3 table-classload.py
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       # ── artifact summary ───────────────────────────────────────────────────
 
       - name: Write artifact summary

--- a/.github/workflows/certificate-ripper-aot-cache.yml
+++ b/.github/workflows/certificate-ripper-aot-cache.yml
@@ -1,0 +1,150 @@
+name: Certificate Ripper AOT Cache
+
+on:
+  workflow_dispatch:
+
+jobs:
+  tree-combine:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          submodules: false
+
+      - name: Init certificate-ripper submodule
+        run: |
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
+          git submodule update --init -- \
+            certificate-ripper-experiment/certificate-ripper
+
+      - name: Download custom JDK
+        uses: ./.github/actions/download-custom-jdk
+
+      - name: Set up custom JDK
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: jdkfile
+          java-version: '25'
+          jdkFile: jdk-custom.tar.gz
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-crip-${{ hashFiles('certificate-ripper-experiment/**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-crip-
+            ${{ runner.os }}-maven-
+
+      - name: Build fat jar
+        working-directory: certificate-ripper-experiment/certificate-ripper
+        run: mvn package -DskipTests -q
+
+      # ── single.aot (Temurin — no-AOT baseline JDK) ──────────────────────────
+
+      - name: Set up JDK 24 (no-AOT baseline and single.aot)
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: temurin
+          java-version: '24'
+
+      - name: Capture Temurin JDK path
+        run: echo "TEMURIN_JAVA_HOME=$JAVA_HOME" >> "$GITHUB_ENV"
+
+      - name: Create single.aot (JDK 24)
+        working-directory: certificate-ripper-experiment
+        run: |
+          set -euo pipefail
+          chmod +x create-single-aot.sh
+          ./create-single-aot.sh
+          for op in print-https export-pem-https print-smtps; do
+            test -f "single-${op}.aot"
+          done
+
+      # ── tree.aot (custom JDK) ─────────────────────────────────────────────
+
+      - name: Re-enable custom JDK
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: jdkfile
+          java-version: '25'
+          jdkFile: jdk-custom.tar.gz
+
+      - name: Create tree.aot (orchestrate-combine.sh)
+        working-directory: certificate-ripper-experiment
+        run: |
+          set -euo pipefail
+          chmod +x orchestrate-combine.sh
+          combine_out=$(./orchestrate-combine.sh 2>&1) || { echo "$combine_out"; exit 1; }
+          echo "$combine_out"
+          combine_out_clean=$(echo "$combine_out" | sed 's/\x1B\[[0-9;]*m//g')
+
+          tree_size=$(du -h tree.aot | awk '{print $1}')
+
+          {
+            echo "## tree.aot creation (orchestrate-combine)"
+            echo
+            echo "- tree.aot: ${tree_size}"
+            echo
+            echo '```'
+            echo "$combine_out_clean"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          test -f tree.aot
+
+      # ── timed workload ───────────────────────────────────────────────────────
+
+      - name: Run timed workload
+        working-directory: certificate-ripper-experiment
+        run: |
+          set -euo pipefail
+          chmod +x workload-timed.sh
+          wl_out=$(JAVA_NO_BIN="$TEMURIN_JAVA_HOME/bin/java" \
+                   JAVA_AOTCACHE_BIN="$TEMURIN_JAVA_HOME/bin/java" \
+                   JAVA_TREECACHE_BIN="$JAVA_HOME/bin/java" \
+                   ./workload-timed.sh 2>&1) || { echo "$wl_out"; exit 1; }
+          echo "$wl_out"
+          wl_out_clean=$(echo "$wl_out" | sed 's/\x1B\[[0-9;]*m//g')
+
+          single_size=$(du -ch single-*.aot | tail -1 | awk '{print $1}')
+          tree_size=$(du -h tree.aot | awk '{print $1}')
+
+          {
+            echo "## Timed workload results (no-AOT vs AOTCache vs TreeCache)"
+            echo
+            echo "- single-*.aot total: ${single_size}"
+            echo "- tree.aot: ${tree_size}"
+            echo
+            echo '```'
+            echo "$wl_out_clean"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Append LaTeX table rows to summary
+        working-directory: certificate-ripper-experiment
+        run: |
+          {
+            echo "## LaTeX table rows (single=AOTCache, tree=TreeCache)"
+            echo
+            echo '```latex'
+            cat workload-tmp/latex-rows.tex
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: certificate-ripper-tree-artifacts
+          path: |
+            certificate-ripper-experiment/workload-tmp/
+            certificate-ripper-experiment/single-print-https.aot
+            certificate-ripper-experiment/single-export-pem-https.aot
+            certificate-ripper-experiment/single-print-smtps.aot
+            certificate-ripper-experiment/cli-print-https.aot
+            certificate-ripper-experiment/cli-export-pem-https.aot
+            certificate-ripper-experiment/cli-print-smtps.aot
+            certificate-ripper-experiment/tree.aot
+            certificate-ripper-experiment/certificate-ripper/cache.aot
+          if-no-files-found: error

--- a/.github/workflows/commons-compress-aot-cache.yml
+++ b/.github/workflows/commons-compress-aot-cache.yml
@@ -1,9 +1,6 @@
 name: Commons Compress Distributed AOT Cache
 
 on:
-  push:
-    branches: [main]
-  pull_request:
   workflow_dispatch:
     inputs:
       single_aot_jdk:

--- a/.github/workflows/commons-compress-iterative-aot.yml
+++ b/.github/workflows/commons-compress-iterative-aot.yml
@@ -1,9 +1,6 @@
 name: Commons Compress Iterative AOT Cache
 
 on:
-  push:
-    branches: [main]
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/commons-configuration-aot-cache.yml
+++ b/.github/workflows/commons-configuration-aot-cache.yml
@@ -1,9 +1,6 @@
 name: Commons Configuration Distributed AOT Cache
 
 on:
-  push:
-    branches: [main]
-  pull_request:
   workflow_dispatch:
     inputs:
       single_aot_jdk:

--- a/.github/workflows/commons-validator-aot-cache.yml
+++ b/.github/workflows/commons-validator-aot-cache.yml
@@ -1,9 +1,6 @@
 name: Commons Validator Distributed AOT Cache
 
 on:
-  push:
-    branches: [main]
-  pull_request:
   workflow_dispatch:
     inputs:
       single_aot_jdk:

--- a/.github/workflows/opennlp-aot-cache.yml
+++ b/.github/workflows/opennlp-aot-cache.yml
@@ -1,9 +1,6 @@
 name: OpenNLP Morfologik AOT Cache
 
 on:
-  push:
-    branches: [main]
-  pull_request:
   workflow_dispatch:
     inputs:
       single_aot_jdk:

--- a/.github/workflows/pdfbox-iterative-aot.yml
+++ b/.github/workflows/pdfbox-iterative-aot.yml
@@ -1,9 +1,6 @@
 name: PDFBox Iterative AOT Cache
 
 on:
-  push:
-    branches: [main]
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/recursively-updating-aot-cache-combined.yml
+++ b/.github/workflows/recursively-updating-aot-cache-combined.yml
@@ -1,6 +1,9 @@
 name: Recursively Updating AOT Cache (tree)
 
 on:
+  push:
+    branches: [main]
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/recursively-updating-aot-cache-combined.yml
+++ b/.github/workflows/recursively-updating-aot-cache-combined.yml
@@ -1,9 +1,6 @@
 name: Recursively Updating AOT Cache (tree)
 
 on:
-  push:
-    branches: [main]
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/biojava-experiment/table-classload.py
+++ b/biojava-experiment/table-classload.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Generate LaTeX table of class-load source counts for biojava RQ1.
+
+Parses classload-{workload}-{scenario}.log files.
+
+Source categories:
+  'shared objects file'           → archive
+  'file://'  /  'jrt://'          → classpath
+  '__JVM_LookupDefineClass__'     → generated
+  '__dynamic_proxy__'             → generated
+  anything else                   → custom classloader (WARNING printed)
+
+Archive classes are further split into JDK / APP by package name.
+
+Output: printed LaTeX table rows (biojava only).
+"""
+import re, os, sys, argparse
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+parser = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+parser.add_argument('--logs-dir', default=os.path.join(HERE, 'workload-tmp'),
+                    help='directory containing classload-*.log files (default: workload-tmp/ next to this script)')
+args = parser.parse_args()
+LOGS_DIR = args.logs_dir
+
+WORKLOADS = ['genbank-write', 'msa', 'aa-prop', 'pdb-parse']
+SCENARIOS = [
+    ('no',        'No cache'),
+    ('AOTCache',  'AOTCache'),
+    ('TreeCache', r'\toolname{}'),
+]
+
+PRIMITIVES = frozenset('ZBCSIFJD')
+JDK_PKGS   = {'java', 'jdk', 'sun', 'javax', 'com.sun'} | PRIMITIVES
+GENERATED  = frozenset({'__JVM_LookupDefineClass__', '__dynamic_proxy__'})
+
+
+def get_pkg(name):
+    while name.startswith('['):
+        name = name[1:]
+    if name.startswith('L') and name.endswith(';'):
+        name = name[1:-1]
+    if not name:
+        return None
+    if '.' not in name:
+        return name if name in PRIMITIVES else None
+    parts = name.split('.')
+    if parts[0] == 'com' and len(parts) >= 2:
+        return parts[0] + '.' + parts[1]
+    return parts[0]
+
+
+def is_jdk(name):
+    pkg = get_pkg(name)
+    return (pkg in JDK_PKGS) if pkg else True
+
+
+def is_classloader_source(src):
+    return (src not in GENERATED
+            and '://' not in src
+            and src != 'shared objects file'
+            and re.match(r'[a-zA-Z_$][\w.$]*$', src) is not None)
+
+
+def parse(log_path):
+    """Return dict with keys: arch_jdk, arch_app, classpath, generated."""
+    arch_jdk = arch_app = classpath = generated = 0
+    with open(log_path) as f:
+        for line in f:
+            m = re.match(r'.*\[class,load\] (\S+) source: (.+)', line.strip())
+            if not m:
+                continue
+            cls, src = m.group(1), m.group(2).strip()
+            if src == 'shared objects file':
+                if is_jdk(cls):
+                    arch_jdk += 1
+                else:
+                    arch_app += 1
+            elif src in GENERATED or is_classloader_source(src):
+                generated += 1
+            elif src.startswith('file:') or src.startswith('jrt:/'):
+                classpath += 1
+            else:
+                print(f'WARNING unknown source: class={cls!r}  source={src!r}',
+                      file=sys.stderr)
+                classpath += 1
+    return dict(arch_jdk=arch_jdk, arch_app=arch_app,
+                classpath=classpath, generated=generated)
+
+
+# ── collect numbers ───────────────────────────────────────────────────────────
+data = {}
+for wl in WORKLOADS:
+    data[wl] = {}
+    for sc_key, _ in SCENARIOS:
+        path = os.path.join(LOGS_DIR, f'classload-{wl}-{sc_key}.log')
+        if not os.path.exists(path):
+            print(f'MISSING: {path}', file=sys.stderr)
+            continue
+        data[wl][sc_key] = parse(path)
+
+# ── emit LaTeX ────────────────────────────────────────────────────────────────
+print(r'\begin{tabular}{@{}ll rrrr r@{}}')
+print(r'\toprule')
+print(r'\textbf{Workload} & \textbf{Scenario}'
+      r' & \textbf{Arch-JDK} & \textbf{Arch-APP}'
+      r' & \textbf{Classpath} & \textbf{Gen.}'
+      r' & \textbf{Total} \\')
+print(r'\midrule')
+
+for wl in WORKLOADS:
+    first = True
+    for sc_key, sc_label in SCENARIOS:
+        if sc_key not in data[wl]:
+            continue
+        s = data[wl][sc_key]
+        total = s['arch_jdk'] + s['arch_app'] + s['classpath'] + s['generated']
+        wl_cell = f'\\texttt{{{wl}}}' if first else ''
+        first = False
+        bold = sc_key == 'TreeCache'
+        def fmt(n, _bold=bold):
+            return f'\\textbf{{{n:,}}}' if _bold else f'{n:,}'
+        print(f'{wl_cell} & {sc_label}'
+              f' & {fmt(s["arch_jdk"])}'
+              f' & {fmt(s["arch_app"])}'
+              f' & {fmt(s["classpath"])}'
+              f' & {fmt(s["generated"])}'
+              f' & {fmt(total)} \\\\')
+    print(r'\midrule')
+
+print(r'\end{tabular}')

--- a/biojava-experiment/workload-timed.sh
+++ b/biojava-experiment/workload-timed.sh
@@ -213,7 +213,7 @@ _print_latex_rows "biojava"
 
 _classload_row() {
   local op="$1" mode="$2"
-  local logfile="$WORK_DIR/cl-${op}-${mode}.log"
+  local logfile="$WORK_DIR/classload-${op}-${mode}.log"
   case "$mode" in
     no)         "$JAVA_NO_BIN"         -Xlog:class+load:file="$logfile" "${BASE_ARGS[@]}" "$MAIN" "$op" "$WORK_DIR" >/dev/null 2>&1 ;;
     AOTCache) "$JAVA_AOTCACHE_BIN" -XX:AOTCache="single-${op}.aot" -XX:+AOTClassLinking \


### PR DESCRIPTION
## Summary

- Disable `push`/`pull_request` triggers on all workflows except **batik**, **biojava**, **thymeleaf**, and **tika** (tree-combine, not iterative) — everything else is now `workflow_dispatch` only
- Add `biojava-experiment/table-classload.py`: generates the Arch-JDK / Arch-APP / Classpath / Gen. / Total LaTeX table (same structure as `commons-configuration-experiment/table-classload.py`)
- Rename biojava class-load log files from `cl-{op}-{mode}.log` → `classload-{op}-{mode}.log` to match the script's expected naming
- Wire up the new table as a "Class-load breakdown" step in the biojava workflow summary

## Test plan

- [ ] Push to this branch and confirm only batik, biojava, thymeleaf, tika workflows trigger
- [ ] Manually dispatch a disabled workflow to confirm it still works on demand
- [ ] After a biojava run, check the step summary includes the Arch-JDK/Arch-APP/Classpath/Gen./Total table

🤖 Generated with [Claude Code](https://claude.com/claude-code)