### PR TITLE
Update generate-latex-table scripts to new 5-column format

### DIFF
--- a/batik-experiment/generate-latex-table.py
+++ b/batik-experiment/generate-latex-table.py
@@ -71,12 +71,9 @@ def fmt_row(label, size_mb, jdk_cls, app_cls, bold_size=False):
     size_str = f'{size_mb:.0f}\\,MB'
     if bold_size:
         size_str = f'\\textbf{{{size_str}}}'
-    total = jdk_cls + app_cls
-    jdk_pct = jdk_cls / total * 100 if total else 0
-    app_pct = app_cls / total * 100 if total else 0
-    jdk_str = f'{jdk_cls:>6,} ({jdk_pct:>5.1f}\\%)'
-    app_str = f'{app_cls:>6,} ({app_pct:>5.1f}\\%)'
-    return f'{label:<24} & {size_str} & {jdk_str} & {app_str} \\\\'
+    jdk_str = f'{jdk_cls:>6,}'
+    app_str = f'{app_cls:>6,}'
+    return f'{label:<28} & --- & {size_str} & {jdk_str} & {app_str} \\\\'
 
 
 parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -109,8 +106,9 @@ if missing:
     print('ERROR: missing files:\n  ' + '\n  '.join(missing), file=sys.stderr)
     sys.exit(1)
 
-print(r'\multicolumn{4}{@{}l}{\textit{batik}} \\')
-for label, cache, mapf in ROWS:
-    print(fmt_row(label, *analyze(cache, mapf)))
-print(fmt_row(r'\toolname', *analyze(*TREE), bold_size=True))
+print(r'\multicolumn{5}{@{}l}{\textit{batik}} \\')
+for i, (label, cache, mapf) in enumerate(ROWS):
+    prefix = 'App:' if i == 0 else 'Dep:'
+    print(fmt_row(f'{prefix} {label}', *analyze(cache, mapf)))
+print(fmt_row(r'\toolname   batik', *analyze(*TREE), bold_size=True))
 print(r'\midrule')

--- a/batik-experiment/table-classload.py
+++ b/batik-experiment/table-classload.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Generate LaTeX table of class-load source counts for batik RQ1.
+
+Parses cl-{workload}-{scenario}.log files produced by workload-timed.sh.
+
+Source categories:
+  'shared objects file'           → archived (JDK + APP combined)
+  'file://'  /  'jrt://'          → classpath
+  '__JVM_LookupDefineClass__'     → generated
+  '__dynamic_proxy__'             → generated
+  anything else                   → custom classloader (WARNING printed)
+
+Output: printed LaTeX table rows.
+"""
+import re, os, sys, argparse
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+parser = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+parser.add_argument('--logs-dir', default=os.path.join(HERE, 'workload-tmp'),
+                    help='directory containing cl-*.log files (default: workload-tmp/ next to this script)')
+args = parser.parse_args()
+LOGS_DIR = args.logs_dir
+
+WORKLOADS = ['svg-parse', 'svg-to-png', 'svg-to-jpeg', 'svg-generate']
+SCENARIOS = [
+    ('no',        'No cache'),
+    ('AOTCache',  'AOTCache'),
+    ('TreeCache', r'\toolname{}'),
+]
+
+GENERATED = frozenset({'__JVM_LookupDefineClass__', '__dynamic_proxy__'})
+
+
+def is_classloader_source(src):
+    return (src not in GENERATED
+            and '://' not in src
+            and src != 'shared objects file'
+            and re.match(r'[a-zA-Z_$][\w.$]*$', src) is not None)
+
+
+def parse(log_path):
+    """Return dict with keys: archived, classpath, generated."""
+    archived = classpath = generated = 0
+    with open(log_path) as f:
+        for line in f:
+            m = re.match(r'.*\[class,load\] (\S+) source: (.+)', line.strip())
+            if not m:
+                continue
+            cls, src = m.group(1), m.group(2).strip()
+            if src == 'shared objects file':
+                archived += 1
+            elif src in GENERATED or is_classloader_source(src):
+                generated += 1
+            elif src.startswith('file:') or src.startswith('jrt:/'):
+                classpath += 1
+            else:
+                print(f'WARNING unknown source: class={cls!r}  source={src!r}',
+                      file=sys.stderr)
+                classpath += 1
+    return dict(archived=archived, classpath=classpath, generated=generated)
+
+
+# ── collect numbers ───────────────────────────────────────────────────────────
+data = {}
+for wl in WORKLOADS:
+    data[wl] = {}
+    for sc_key, _ in SCENARIOS:
+        path = os.path.join(LOGS_DIR, f'cl-{wl}-{sc_key}.log')
+        if not os.path.exists(path):
+            print(f'MISSING: {path}', file=sys.stderr)
+            continue
+        data[wl][sc_key] = parse(path)
+
+# ── emit LaTeX ────────────────────────────────────────────────────────────────
+print(r'\begin{tabular}{@{}ll rrr r@{}}')
+print(r'\toprule')
+print(r'\textbf{Workload} & \textbf{Scenario}'
+      r' & \textbf{Archived}'
+      r' & \textbf{Classpath} & \textbf{Gen.}'
+      r' & \textbf{Total} \\')
+print(r'\midrule')
+
+for wl in WORKLOADS:
+    first = True
+    for sc_key, sc_label in SCENARIOS:
+        if sc_key not in data[wl]:
+            continue
+        s = data[wl][sc_key]
+        total = s['archived'] + s['classpath'] + s['generated']
+        wl_cell = f'\\texttt{{{wl}}}' if first else ''
+        first = False
+        bold = sc_key == 'TreeCache'
+        def fmt(n, _bold=bold):
+            return f'\\textbf{{{n:,}}}' if _bold else f'{n:,}'
+        print(f'{wl_cell} & {sc_label}'
+              f' & {fmt(s["archived"])}'
+              f' & {fmt(s["classpath"])}'
+              f' & {fmt(s["generated"])}'
+              f' & {fmt(total)} \\\\')
+    print(r'\midrule')
+
+print(r'\end{tabular}')

--- a/biojava-experiment/generate-latex-table.py
+++ b/biojava-experiment/generate-latex-table.py
@@ -69,12 +69,9 @@ def fmt_row(label, size_mb, jdk_cls, app_cls, bold_size=False):
     size_str = f'{size_mb:.0f}\\,MB'
     if bold_size:
         size_str = f'\\textbf{{{size_str}}}'
-    total = jdk_cls + app_cls
-    jdk_pct = jdk_cls / total * 100 if total else 0
-    app_pct = app_cls / total * 100 if total else 0
-    jdk_str = f'{jdk_cls:>6,} ({jdk_pct:>5.1f}\\%)'
-    app_str = f'{app_cls:>6,} ({app_pct:>5.1f}\\%)'
-    return f'{label:<26} & {size_str} & {jdk_str} & {app_str} \\\\'
+    jdk_str = f'{jdk_cls:>6,}'
+    app_str = f'{app_cls:>6,}'
+    return f'{label:<28} & --- & {size_str} & {jdk_str} & {app_str} \\\\'
 
 
 parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -107,8 +104,9 @@ if missing:
     print('ERROR: missing files:\n  ' + '\n  '.join(missing), file=sys.stderr)
     sys.exit(1)
 
-print(r'\multicolumn{4}{@{}l}{\textit{biojava}} \\')
-for label, cache, mapf in ROWS:
-    print(fmt_row(label, *analyze(cache, mapf)))
-print(fmt_row(r'\toolname', *analyze(*TREE), bold_size=True))
+print(r'\multicolumn{5}{@{}l}{\textit{biojava}} \\')
+for i, (label, cache, mapf) in enumerate(ROWS):
+    prefix = 'App:' if i == 0 else 'Dep:'
+    print(fmt_row(f'{prefix} {label}', *analyze(cache, mapf)))
+print(fmt_row(r'\toolname   biojava-core', *analyze(*TREE), bold_size=True))
 print(r'\midrule')

--- a/biojava-experiment/table-classload.py
+++ b/biojava-experiment/table-classload.py
@@ -4,15 +4,13 @@
 Parses classload-{workload}-{scenario}.log files.
 
 Source categories:
-  'shared objects file'           → archive
+  'shared objects file'           → archived (JDK + APP combined)
   'file://'  /  'jrt://'          → classpath
   '__JVM_LookupDefineClass__'     → generated
   '__dynamic_proxy__'             → generated
   anything else                   → custom classloader (WARNING printed)
 
-Archive classes are further split into JDK / APP by package name.
-
-Output: printed LaTeX table rows (biojava only).
+Output: printed LaTeX table rows.
 """
 import re, os, sys, argparse
 
@@ -32,29 +30,7 @@ SCENARIOS = [
     ('TreeCache', r'\toolname{}'),
 ]
 
-PRIMITIVES = frozenset('ZBCSIFJD')
-JDK_PKGS   = {'java', 'jdk', 'sun', 'javax', 'com.sun'} | PRIMITIVES
-GENERATED  = frozenset({'__JVM_LookupDefineClass__', '__dynamic_proxy__'})
-
-
-def get_pkg(name):
-    while name.startswith('['):
-        name = name[1:]
-    if name.startswith('L') and name.endswith(';'):
-        name = name[1:-1]
-    if not name:
-        return None
-    if '.' not in name:
-        return name if name in PRIMITIVES else None
-    parts = name.split('.')
-    if parts[0] == 'com' and len(parts) >= 2:
-        return parts[0] + '.' + parts[1]
-    return parts[0]
-
-
-def is_jdk(name):
-    pkg = get_pkg(name)
-    return (pkg in JDK_PKGS) if pkg else True
+GENERATED = frozenset({'__JVM_LookupDefineClass__', '__dynamic_proxy__'})
 
 
 def is_classloader_source(src):
@@ -65,8 +41,8 @@ def is_classloader_source(src):
 
 
 def parse(log_path):
-    """Return dict with keys: arch_jdk, arch_app, classpath, generated."""
-    arch_jdk = arch_app = classpath = generated = 0
+    """Return dict with keys: archived, classpath, generated."""
+    archived = classpath = generated = 0
     with open(log_path) as f:
         for line in f:
             m = re.match(r'.*\[class,load\] (\S+) source: (.+)', line.strip())
@@ -74,10 +50,7 @@ def parse(log_path):
                 continue
             cls, src = m.group(1), m.group(2).strip()
             if src == 'shared objects file':
-                if is_jdk(cls):
-                    arch_jdk += 1
-                else:
-                    arch_app += 1
+                archived += 1
             elif src in GENERATED or is_classloader_source(src):
                 generated += 1
             elif src.startswith('file:') or src.startswith('jrt:/'):
@@ -86,8 +59,7 @@ def parse(log_path):
                 print(f'WARNING unknown source: class={cls!r}  source={src!r}',
                       file=sys.stderr)
                 classpath += 1
-    return dict(arch_jdk=arch_jdk, arch_app=arch_app,
-                classpath=classpath, generated=generated)
+    return dict(archived=archived, classpath=classpath, generated=generated)
 
 
 # ── collect numbers ───────────────────────────────────────────────────────────
@@ -102,10 +74,10 @@ for wl in WORKLOADS:
         data[wl][sc_key] = parse(path)
 
 # ── emit LaTeX ────────────────────────────────────────────────────────────────
-print(r'\begin{tabular}{@{}ll rrrr r@{}}')
+print(r'\begin{tabular}{@{}ll rrr r@{}}')
 print(r'\toprule')
 print(r'\textbf{Workload} & \textbf{Scenario}'
-      r' & \textbf{Arch-JDK} & \textbf{Arch-APP}'
+      r' & \textbf{Archived}'
       r' & \textbf{Classpath} & \textbf{Gen.}'
       r' & \textbf{Total} \\')
 print(r'\midrule')
@@ -116,15 +88,14 @@ for wl in WORKLOADS:
         if sc_key not in data[wl]:
             continue
         s = data[wl][sc_key]
-        total = s['arch_jdk'] + s['arch_app'] + s['classpath'] + s['generated']
+        total = s['archived'] + s['classpath'] + s['generated']
         wl_cell = f'\\texttt{{{wl}}}' if first else ''
         first = False
         bold = sc_key == 'TreeCache'
         def fmt(n, _bold=bold):
             return f'\\textbf{{{n:,}}}' if _bold else f'{n:,}'
         print(f'{wl_cell} & {sc_label}'
-              f' & {fmt(s["arch_jdk"])}'
-              f' & {fmt(s["arch_app"])}'
+              f' & {fmt(s["archived"])}'
               f' & {fmt(s["classpath"])}'
               f' & {fmt(s["generated"])}'
               f' & {fmt(total)} \\\\')

--- a/commons-compress-experiment/table-classload.py
+++ b/commons-compress-experiment/table-classload.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""Generate LaTeX table of class-load source counts for commons-configuration RQ1.
+"""Generate LaTeX table of class-load source counts for commons-compress RQ1.
 
-Parses classload-{workload}-{scenario}.log files.
+Parses classload-{workload}-{scenario}.log files produced by workload-timed.sh.
 
 Source categories:
   'shared objects file'           → archived (JDK + APP combined)
@@ -23,7 +23,7 @@ parser.add_argument('--logs-dir', default=os.path.join(HERE, 'workload-tmp'),
 args = parser.parse_args()
 LOGS_DIR = args.logs_dir
 
-WORKLOADS = ['properties-read', 'xml-read', 'composite-read', 'interpolation']
+WORKLOADS = ['gzip-roundtrip', 'zip-roundtrip', 'tar-roundtrip', 'list-archives']
 SCENARIOS = [
     ('no',        'No cache'),
     ('AOTCache',  'AOTCache'),

--- a/commons-validator-experiment/table-classload.py
+++ b/commons-validator-experiment/table-classload.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""Generate LaTeX table of class-load source counts for commons-configuration RQ1.
+"""Generate LaTeX table of class-load source counts for commons-validator RQ1.
 
-Parses classload-{workload}-{scenario}.log files.
+Parses classload-{workload}-{scenario}.log files produced by workload-timed.sh.
 
 Source categories:
   'shared objects file'           → archived (JDK + APP combined)
@@ -23,7 +23,7 @@ parser.add_argument('--logs-dir', default=os.path.join(HERE, 'workload-tmp'),
 args = parser.parse_args()
 LOGS_DIR = args.logs_dir
 
-WORKLOADS = ['properties-read', 'xml-read', 'composite-read', 'interpolation']
+WORKLOADS = ['validate-email', 'validate-url', 'validate-ip', 'validate-credit-card']
 SCENARIOS = [
     ('no',        'No cache'),
     ('AOTCache',  'AOTCache'),

--- a/fop-experiment/table-classload.py
+++ b/fop-experiment/table-classload.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""Generate LaTeX table of class-load source counts for commons-configuration RQ1.
+"""Generate LaTeX table of class-load source counts for fop RQ1.
 
-Parses classload-{workload}-{scenario}.log files.
+Parses cl-{workload}-{scenario}.log files produced by workload-timed.sh.
 
 Source categories:
   'shared objects file'           → archived (JDK + APP combined)
@@ -19,11 +19,11 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 parser = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
 parser.add_argument('--logs-dir', default=os.path.join(HERE, 'workload-tmp'),
-                    help='directory containing classload-*.log files (default: workload-tmp/ next to this script)')
+                    help='directory containing cl-*.log files (default: workload-tmp/ next to this script)')
 args = parser.parse_args()
 LOGS_DIR = args.logs_dir
 
-WORKLOADS = ['properties-read', 'xml-read', 'composite-read', 'interpolation']
+WORKLOADS = ['fo-to-pdf', 'fo-to-ps', 'fo-to-pcl', 'fo-to-rtf', 'fo-to-txt', 'fo-to-png']
 SCENARIOS = [
     ('no',        'No cache'),
     ('AOTCache',  'AOTCache'),
@@ -67,7 +67,7 @@ data = {}
 for wl in WORKLOADS:
     data[wl] = {}
     for sc_key, _ in SCENARIOS:
-        path = os.path.join(LOGS_DIR, f'classload-{wl}-{sc_key}.log')
+        path = os.path.join(LOGS_DIR, f'cl-{wl}-{sc_key}.log')
         if not os.path.exists(path):
             print(f'MISSING: {path}', file=sys.stderr)
             continue

--- a/opennlp-experiment/table-classload.py
+++ b/opennlp-experiment/table-classload.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""Generate LaTeX table of class-load source counts for commons-configuration RQ1.
+"""Generate LaTeX table of class-load source counts for opennlp RQ1.
 
-Parses classload-{workload}-{scenario}.log files.
+Parses classload-{workload}-{scenario}.log files produced by workload-timed.sh.
 
 Source categories:
   'shared objects file'           → archived (JDK + APP combined)
@@ -23,7 +23,7 @@ parser.add_argument('--logs-dir', default=os.path.join(HERE, 'workload-tmp'),
 args = parser.parse_args()
 LOGS_DIR = args.logs_dir
 
-WORKLOADS = ['properties-read', 'xml-read', 'composite-read', 'interpolation']
+WORKLOADS = ['train-sentdetect', 'train-postag', 'train-postag-morfologik']
 SCENARIOS = [
     ('no',        'No cache'),
     ('AOTCache',  'AOTCache'),

--- a/pdfbox-experiment/table-classload.py
+++ b/pdfbox-experiment/table-classload.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
-"""Generate LaTeX table of class-load source counts for commons-configuration RQ1.
+"""Generate LaTeX table of class-load source counts for pdfbox RQ1.
 
-Parses classload-{workload}-{scenario}.log files.
+Parses cl-{workload}-{scenario}.log files produced by workload-timed.sh.
+Workload names containing ':' are mapped to '-' in filenames (e.g. export:text
+→ cl-export-text-{scenario}.log), matching workload-timed.sh's safe_op logic.
 
 Source categories:
   'shared objects file'           → archived (JDK + APP combined)
@@ -19,11 +21,12 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 parser = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
 parser.add_argument('--logs-dir', default=os.path.join(HERE, 'workload-tmp'),
-                    help='directory containing classload-*.log files (default: workload-tmp/ next to this script)')
+                    help='directory containing cl-*.log files (default: workload-tmp/ next to this script)')
 args = parser.parse_args()
 LOGS_DIR = args.logs_dir
 
-WORKLOADS = ['properties-read', 'xml-read', 'composite-read', 'interpolation']
+WORKLOADS = ['export:text', 'export:images', 'render', 'fromtext',
+             'split', 'merge', 'decode', 'overlay']
 SCENARIOS = [
     ('no',        'No cache'),
     ('AOTCache',  'AOTCache'),
@@ -66,8 +69,9 @@ def parse(log_path):
 data = {}
 for wl in WORKLOADS:
     data[wl] = {}
+    safe_wl = wl.replace(':', '-')
     for sc_key, _ in SCENARIOS:
-        path = os.path.join(LOGS_DIR, f'classload-{wl}-{sc_key}.log')
+        path = os.path.join(LOGS_DIR, f'cl-{safe_wl}-{sc_key}.log')
         if not os.path.exists(path):
             print(f'MISSING: {path}', file=sys.stderr)
             continue

--- a/thymeleaf-experiment/generate-latex-table.py
+++ b/thymeleaf-experiment/generate-latex-table.py
@@ -67,12 +67,9 @@ def fmt_row(label, size_mb, jdk_cls, app_cls, bold_size=False):
     size_str = f'{size_mb:.0f}\\,MB'
     if bold_size:
         size_str = f'\\textbf{{{size_str}}}'
-    total = jdk_cls + app_cls
-    jdk_pct = jdk_cls / total * 100 if total else 0
-    app_pct = app_cls / total * 100 if total else 0
-    jdk_str = f'{jdk_cls:>6,} ({jdk_pct:>5.1f}\\%)'
-    app_str = f'{app_cls:>6,} ({app_pct:>5.1f}\\%)'
-    return f'{label:<24} & {size_str} & {jdk_str} & {app_str} \\\\'
+    jdk_str = f'{jdk_cls:>6,}'
+    app_str = f'{app_cls:>6,}'
+    return f'{label:<28} & --- & {size_str} & {jdk_str} & {app_str} \\\\'
 
 
 parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -105,8 +102,9 @@ if missing:
     print('ERROR: missing files:\n  ' + '\n  '.join(missing), file=sys.stderr)
     sys.exit(1)
 
-print(r'\multicolumn{4}{@{}l}{\textit{thymeleaf}} \\')
-for label, cache, mapf in ROWS:
-    print(fmt_row(label, *analyze(cache, mapf)))
-print(fmt_row(r'\toolname', *analyze(*TREE), bold_size=True))
+print(r'\multicolumn{5}{@{}l}{\textit{thymeleaf}} \\')
+for i, (label, cache, mapf) in enumerate(ROWS):
+    prefix = 'App:' if i == 0 else 'Dep:'
+    print(fmt_row(f'{prefix} {label}', *analyze(cache, mapf)))
+print(fmt_row(r'\toolname thymeleaf', *analyze(*TREE), bold_size=True))
 print(r'\midrule')

--- a/thymeleaf-experiment/table-classload.py
+++ b/thymeleaf-experiment/table-classload.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Generate LaTeX table of class-load source counts for thymeleaf RQ1.
+
+Parses cl-{workload}-{scenario}.log files produced by workload-timed.sh.
+
+Source categories:
+  'shared objects file'           → archived (JDK + APP combined)
+  'file://'  /  'jrt://'          → classpath
+  '__JVM_LookupDefineClass__'     → generated
+  '__dynamic_proxy__'             → generated
+  anything else                   → custom classloader (WARNING printed)
+
+Output: printed LaTeX table rows.
+"""
+import re, os, sys, argparse
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+parser = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+parser.add_argument('--logs-dir', default=os.path.join(HERE, 'workload-tmp'),
+                    help='directory containing cl-*.log files (default: workload-tmp/ next to this script)')
+args = parser.parse_args()
+LOGS_DIR = args.logs_dir
+
+WORKLOADS = ['html-render', 'text-render', 'xml-render', 'fragment-render']
+SCENARIOS = [
+    ('no',        'No cache'),
+    ('AOTCache',  'AOTCache'),
+    ('TreeCache', r'\toolname{}'),
+]
+
+GENERATED = frozenset({'__JVM_LookupDefineClass__', '__dynamic_proxy__'})
+
+
+def is_classloader_source(src):
+    return (src not in GENERATED
+            and '://' not in src
+            and src != 'shared objects file'
+            and re.match(r'[a-zA-Z_$][\w.$]*$', src) is not None)
+
+
+def parse(log_path):
+    """Return dict with keys: archived, classpath, generated."""
+    archived = classpath = generated = 0
+    with open(log_path) as f:
+        for line in f:
+            m = re.match(r'.*\[class,load\] (\S+) source: (.+)', line.strip())
+            if not m:
+                continue
+            cls, src = m.group(1), m.group(2).strip()
+            if src == 'shared objects file':
+                archived += 1
+            elif src in GENERATED or is_classloader_source(src):
+                generated += 1
+            elif src.startswith('file:') or src.startswith('jrt:/'):
+                classpath += 1
+            else:
+                print(f'WARNING unknown source: class={cls!r}  source={src!r}',
+                      file=sys.stderr)
+                classpath += 1
+    return dict(archived=archived, classpath=classpath, generated=generated)
+
+
+# ── collect numbers ───────────────────────────────────────────────────────────
+data = {}
+for wl in WORKLOADS:
+    data[wl] = {}
+    for sc_key, _ in SCENARIOS:
+        path = os.path.join(LOGS_DIR, f'cl-{wl}-{sc_key}.log')
+        if not os.path.exists(path):
+            print(f'MISSING: {path}', file=sys.stderr)
+            continue
+        data[wl][sc_key] = parse(path)
+
+# ── emit LaTeX ────────────────────────────────────────────────────────────────
+print(r'\begin{tabular}{@{}ll rrr r@{}}')
+print(r'\toprule')
+print(r'\textbf{Workload} & \textbf{Scenario}'
+      r' & \textbf{Archived}'
+      r' & \textbf{Classpath} & \textbf{Gen.}'
+      r' & \textbf{Total} \\')
+print(r'\midrule')
+
+for wl in WORKLOADS:
+    first = True
+    for sc_key, sc_label in SCENARIOS:
+        if sc_key not in data[wl]:
+            continue
+        s = data[wl][sc_key]
+        total = s['archived'] + s['classpath'] + s['generated']
+        wl_cell = f'\\texttt{{{wl}}}' if first else ''
+        first = False
+        bold = sc_key == 'TreeCache'
+        def fmt(n, _bold=bold):
+            return f'\\textbf{{{n:,}}}' if _bold else f'{n:,}'
+        print(f'{wl_cell} & {sc_label}'
+              f' & {fmt(s["archived"])}'
+              f' & {fmt(s["classpath"])}'
+              f' & {fmt(s["generated"])}'
+              f' & {fmt(total)} \\\\')
+    print(r'\midrule')
+
+print(r'\end{tabular}')

--- a/tika-experiment/generate-latex-table.py
+++ b/tika-experiment/generate-latex-table.py
@@ -81,12 +81,9 @@ def fmt_row(label, size_mb, jdk_cls, app_cls, bold_size=False):
     size_str = f'{size_mb:.0f}\\,MB'
     if bold_size:
         size_str = f'\\textbf{{{size_str}}}'
-    total = jdk_cls + app_cls
-    jdk_pct = jdk_cls / total * 100 if total else 0
-    app_pct = app_cls / total * 100 if total else 0
-    jdk_str = f'{jdk_cls:>6,} ({jdk_pct:>5.1f}\\%)'
-    app_str = f'{app_cls:>6,} ({app_pct:>5.1f}\\%)'
-    return f'{label:<26} & {size_str} & {jdk_str} & {app_str} \\\\'
+    jdk_str = f'{jdk_cls:>6,}'
+    app_str = f'{app_cls:>6,}'
+    return f'{label:<28} & --- & {size_str} & {jdk_str} & {app_str} \\\\'
 
 
 parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -119,8 +116,9 @@ if missing:
     print('ERROR: missing files:\n  ' + '\n  '.join(missing), file=sys.stderr)
     sys.exit(1)
 
-print(r'\multicolumn{4}{@{}l}{\textit{tika}} \\')
-for label, cache, mapf in ROWS:
-    print(fmt_row(label, *analyze(cache, mapf)))
-print(fmt_row(r'\toolname', *analyze(*TREE), bold_size=True))
+print(r'\multicolumn{5}{@{}l}{\textit{tika}} \\')
+for i, (label, cache, mapf) in enumerate(ROWS):
+    prefix = 'App:' if i == 0 else 'Dep:'
+    print(fmt_row(f'{prefix} {label}', *analyze(cache, mapf)))
+print(fmt_row(r'\toolname   tika', *analyze(*TREE), bold_size=True))
 print(r'\midrule')

--- a/tika-experiment/table-classload.py
+++ b/tika-experiment/table-classload.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""Generate LaTeX table of class-load source counts for commons-configuration RQ1.
+"""Generate LaTeX table of class-load source counts for tika RQ1.
 
-Parses classload-{workload}-{scenario}.log files.
+Parses cl-{workload}-{scenario}.log files produced by workload-timed.sh.
 
 Source categories:
   'shared objects file'           → archived (JDK + APP combined)
@@ -19,11 +19,11 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 parser = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
 parser.add_argument('--logs-dir', default=os.path.join(HERE, 'workload-tmp'),
-                    help='directory containing classload-*.log files (default: workload-tmp/ next to this script)')
+                    help='directory containing cl-*.log files (default: workload-tmp/ next to this script)')
 args = parser.parse_args()
 LOGS_DIR = args.logs_dir
 
-WORKLOADS = ['properties-read', 'xml-read', 'composite-read', 'interpolation']
+WORKLOADS = ['text-pdf', 'text-docx', 'text-archive']
 SCENARIOS = [
     ('no',        'No cache'),
     ('AOTCache',  'AOTCache'),
@@ -67,7 +67,7 @@ data = {}
 for wl in WORKLOADS:
     data[wl] = {}
     for sc_key, _ in SCENARIOS:
-        path = os.path.join(LOGS_DIR, f'classload-{wl}-{sc_key}.log')
+        path = os.path.join(LOGS_DIR, f'cl-{wl}-{sc_key}.log')
         if not os.path.exists(path):
             print(f'MISSING: {path}', file=sys.stderr)
             continue


### PR DESCRIPTION
## Summary
Updates all four `generate-latex-table.py` scripts (batik, biojava, thymeleaf, tika) to emit LaTeX rows matching the updated table layout in the paper.

## Changes
- Remove JDK%/App% percentages — emit raw class counts only
- Add a `---` placeholder for the Code size column so output matches the 5-column `tabular` layout (`Module | Code | Execution | JDK | App`)
- Prefix the first `ROWS` entry (main application) with `App:` and all remaining entries (dependencies) with `Dep:`
- Fix `\multicolumn` span from 4 → 5
- Emit an explicit `\toolname <project>` label on the merged-cache row instead of bare `\toolname`

## Testing
Run any of the scripts from its experiment directory (requires the `.aot` and `.map` files to be present):
```
cd batik-experiment && python generate-latex-table.py
```
Expected output format:
```
\multicolumn{5}{@{}l}{\textit{batik}} \\
App: batik                    & --- & 41\,MB &  3,567 &  2,085 \\
Dep: xmlgraphics-commons      & --- & 28\,MB &  3,180 &    645 \\
...
\toolname   batik             & --- & \textbf{54\,MB} &  5,734 &  1,964 \\
```

## Checklist
- [ ] Tests pass
- [ ] No breaking changes