### PR TITLE
Split Arch-JDK/Arch-APP in Batik and Thymeleaf class-load tables

### DIFF
--- a/.github/workflows/batik-aot-cache.yml
+++ b/.github/workflows/batik-aot-cache.yml
@@ -203,6 +203,17 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Append class-load breakdown table to summary
+        working-directory: batik-experiment
+        run: |
+          {
+            echo "## Class-load breakdown (Arch-JDK / Arch-APP / Classpath / Gen.)"
+            echo
+            echo '```latex'
+            python3 table-classload.py
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Append AOT cache composition table to summary
         working-directory: batik-experiment
         run: |

--- a/.github/workflows/thymeleaf-aot-cache.yml
+++ b/.github/workflows/thymeleaf-aot-cache.yml
@@ -193,6 +193,17 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Append class-load breakdown table to summary
+        working-directory: thymeleaf-experiment
+        run: |
+          {
+            echo "## Class-load breakdown (Arch-JDK / Arch-APP / Classpath / Gen.)"
+            echo
+            echo '```latex'
+            python3 table-classload.py
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Append AOT cache composition table to summary
         working-directory: thymeleaf-experiment
         run: |

--- a/batik-experiment/table-classload.py
+++ b/batik-experiment/table-classload.py
@@ -4,7 +4,7 @@
 Parses cl-{workload}-{scenario}.log files produced by workload-timed.sh.
 
 Source categories:
-  'shared objects file'           → archived (JDK + APP combined)
+  'shared objects file'           → archive (split into JDK / APP by package)
   'file://'  /  'jrt://'          → classpath
   '__JVM_LookupDefineClass__'     → generated
   '__dynamic_proxy__'             → generated
@@ -30,7 +30,29 @@ SCENARIOS = [
     ('TreeCache', r'\toolname{}'),
 ]
 
-GENERATED = frozenset({'__JVM_LookupDefineClass__', '__dynamic_proxy__'})
+PRIMITIVES = frozenset('ZBCSIFJD')
+JDK_PKGS   = {'java', 'jdk', 'sun', 'javax', 'com.sun'} | PRIMITIVES
+GENERATED  = frozenset({'__JVM_LookupDefineClass__', '__dynamic_proxy__'})
+
+
+def get_pkg(name):
+    while name.startswith('['):
+        name = name[1:]
+    if name.startswith('L') and name.endswith(';'):
+        name = name[1:-1]
+    if not name:
+        return None
+    if '.' not in name:
+        return name if name in PRIMITIVES else None
+    parts = name.split('.')
+    if parts[0] == 'com' and len(parts) >= 2:
+        return parts[0] + '.' + parts[1]
+    return parts[0]
+
+
+def is_jdk(name):
+    pkg = get_pkg(name)
+    return (pkg in JDK_PKGS) if pkg else True
 
 
 def is_classloader_source(src):
@@ -41,8 +63,8 @@ def is_classloader_source(src):
 
 
 def parse(log_path):
-    """Return dict with keys: archived, classpath, generated."""
-    archived = classpath = generated = 0
+    """Return dict with keys: arch_jdk, arch_app, classpath, generated."""
+    arch_jdk = arch_app = classpath = generated = 0
     with open(log_path) as f:
         for line in f:
             m = re.match(r'.*\[class,load\] (\S+) source: (.+)', line.strip())
@@ -50,7 +72,10 @@ def parse(log_path):
                 continue
             cls, src = m.group(1), m.group(2).strip()
             if src == 'shared objects file':
-                archived += 1
+                if is_jdk(cls):
+                    arch_jdk += 1
+                else:
+                    arch_app += 1
             elif src in GENERATED or is_classloader_source(src):
                 generated += 1
             elif src.startswith('file:') or src.startswith('jrt:/'):
@@ -59,7 +84,8 @@ def parse(log_path):
                 print(f'WARNING unknown source: class={cls!r}  source={src!r}',
                       file=sys.stderr)
                 classpath += 1
-    return dict(archived=archived, classpath=classpath, generated=generated)
+    return dict(arch_jdk=arch_jdk, arch_app=arch_app,
+                classpath=classpath, generated=generated)
 
 
 # ── collect numbers ───────────────────────────────────────────────────────────
@@ -74,10 +100,10 @@ for wl in WORKLOADS:
         data[wl][sc_key] = parse(path)
 
 # ── emit LaTeX ────────────────────────────────────────────────────────────────
-print(r'\begin{tabular}{@{}ll rrr r@{}}')
+print(r'\begin{tabular}{@{}ll rrrr r@{}}')
 print(r'\toprule')
 print(r'\textbf{Workload} & \textbf{Scenario}'
-      r' & \textbf{Archived}'
+      r' & \textbf{Arch-JDK} & \textbf{Arch-APP}'
       r' & \textbf{Classpath} & \textbf{Gen.}'
       r' & \textbf{Total} \\')
 print(r'\midrule')
@@ -88,14 +114,15 @@ for wl in WORKLOADS:
         if sc_key not in data[wl]:
             continue
         s = data[wl][sc_key]
-        total = s['archived'] + s['classpath'] + s['generated']
+        total = s['arch_jdk'] + s['arch_app'] + s['classpath'] + s['generated']
         wl_cell = f'\\texttt{{{wl}}}' if first else ''
         first = False
         bold = sc_key == 'TreeCache'
         def fmt(n, _bold=bold):
             return f'\\textbf{{{n:,}}}' if _bold else f'{n:,}'
         print(f'{wl_cell} & {sc_label}'
-              f' & {fmt(s["archived"])}'
+              f' & {fmt(s["arch_jdk"])}'
+              f' & {fmt(s["arch_app"])}'
               f' & {fmt(s["classpath"])}'
               f' & {fmt(s["generated"])}'
               f' & {fmt(total)} \\\\')

--- a/thymeleaf-experiment/table-classload.py
+++ b/thymeleaf-experiment/table-classload.py
@@ -4,7 +4,7 @@
 Parses cl-{workload}-{scenario}.log files produced by workload-timed.sh.
 
 Source categories:
-  'shared objects file'           → archived (JDK + APP combined)
+  'shared objects file'           → archive (split into JDK / APP by package)
   'file://'  /  'jrt://'          → classpath
   '__JVM_LookupDefineClass__'     → generated
   '__dynamic_proxy__'             → generated
@@ -30,7 +30,29 @@ SCENARIOS = [
     ('TreeCache', r'\toolname{}'),
 ]
 
-GENERATED = frozenset({'__JVM_LookupDefineClass__', '__dynamic_proxy__'})
+PRIMITIVES = frozenset('ZBCSIFJD')
+JDK_PKGS   = {'java', 'jdk', 'sun', 'javax', 'com.sun'} | PRIMITIVES
+GENERATED  = frozenset({'__JVM_LookupDefineClass__', '__dynamic_proxy__'})
+
+
+def get_pkg(name):
+    while name.startswith('['):
+        name = name[1:]
+    if name.startswith('L') and name.endswith(';'):
+        name = name[1:-1]
+    if not name:
+        return None
+    if '.' not in name:
+        return name if name in PRIMITIVES else None
+    parts = name.split('.')
+    if parts[0] == 'com' and len(parts) >= 2:
+        return parts[0] + '.' + parts[1]
+    return parts[0]
+
+
+def is_jdk(name):
+    pkg = get_pkg(name)
+    return (pkg in JDK_PKGS) if pkg else True
 
 
 def is_classloader_source(src):
@@ -41,8 +63,8 @@ def is_classloader_source(src):
 
 
 def parse(log_path):
-    """Return dict with keys: archived, classpath, generated."""
-    archived = classpath = generated = 0
+    """Return dict with keys: arch_jdk, arch_app, classpath, generated."""
+    arch_jdk = arch_app = classpath = generated = 0
     with open(log_path) as f:
         for line in f:
             m = re.match(r'.*\[class,load\] (\S+) source: (.+)', line.strip())
@@ -50,7 +72,10 @@ def parse(log_path):
                 continue
             cls, src = m.group(1), m.group(2).strip()
             if src == 'shared objects file':
-                archived += 1
+                if is_jdk(cls):
+                    arch_jdk += 1
+                else:
+                    arch_app += 1
             elif src in GENERATED or is_classloader_source(src):
                 generated += 1
             elif src.startswith('file:') or src.startswith('jrt:/'):
@@ -59,7 +84,8 @@ def parse(log_path):
                 print(f'WARNING unknown source: class={cls!r}  source={src!r}',
                       file=sys.stderr)
                 classpath += 1
-    return dict(archived=archived, classpath=classpath, generated=generated)
+    return dict(arch_jdk=arch_jdk, arch_app=arch_app,
+                classpath=classpath, generated=generated)
 
 
 # ── collect numbers ───────────────────────────────────────────────────────────
@@ -74,10 +100,10 @@ for wl in WORKLOADS:
         data[wl][sc_key] = parse(path)
 
 # ── emit LaTeX ────────────────────────────────────────────────────────────────
-print(r'\begin{tabular}{@{}ll rrr r@{}}')
+print(r'\begin{tabular}{@{}ll rrrr r@{}}')
 print(r'\toprule')
 print(r'\textbf{Workload} & \textbf{Scenario}'
-      r' & \textbf{Archived}'
+      r' & \textbf{Arch-JDK} & \textbf{Arch-APP}'
       r' & \textbf{Classpath} & \textbf{Gen.}'
       r' & \textbf{Total} \\')
 print(r'\midrule')
@@ -88,14 +114,15 @@ for wl in WORKLOADS:
         if sc_key not in data[wl]:
             continue
         s = data[wl][sc_key]
-        total = s['archived'] + s['classpath'] + s['generated']
+        total = s['arch_jdk'] + s['arch_app'] + s['classpath'] + s['generated']
         wl_cell = f'\\texttt{{{wl}}}' if first else ''
         first = False
         bold = sc_key == 'TreeCache'
         def fmt(n, _bold=bold):
             return f'\\textbf{{{n:,}}}' if _bold else f'{n:,}'
         print(f'{wl_cell} & {sc_label}'
-              f' & {fmt(s["archived"])}'
+              f' & {fmt(s["arch_jdk"])}'
+              f' & {fmt(s["arch_app"])}'
               f' & {fmt(s["classpath"])}'
               f' & {fmt(s["generated"])}'
               f' & {fmt(total)} \\\\')


### PR DESCRIPTION
## Summary

- Update `table-classload.py` for both Batik and Thymeleaf to split the single `Archived` column into `Arch-JDK` and `Arch-APP` using package-name heuristics (`java`/`jdk`/`sun`/`javax`/`com.sun` → JDK), matching the format already used by biojava and commons-configuration
- Add missing "Append class-load breakdown table to summary" CI step to `batik-aot-cache.yml` and `thymeleaf-aot-cache.yml` so the LaTeX table appears in the workflow summary

## Test plan

- [ ] Batik CI summary includes a `Class-load breakdown (Arch-JDK / Arch-APP / Classpath / Gen.)` section with a 6-column LaTeX table
- [ ] Thymeleaf CI summary includes the same section
- [ ] Arch-JDK + Arch-APP counts sum to what was previously shown as `Archived`

🤖 Generated with [Claude Code](https://claude.com/claude-code)