### PR TITLE
Add build-overhead measurement scripts for all tree-combine experiments

### DIFF
--- a/.github/workflows/batik-aot-cache.yml
+++ b/.github/workflows/batik-aot-cache.yml
@@ -255,6 +255,23 @@ jobs:
 
       # ── upload ─────────────────────────────────────────────────────────────
 
+      - name: Measure build overhead
+        working-directory: batik-experiment
+        run: |
+          chmod +x measure-build-overhead.sh
+          ./measure-build-overhead.sh
+
+      - name: Append build overhead table to summary
+        working-directory: batik-experiment
+        run: |
+          {
+            echo "## Build overhead (baseline vs. cache production)"
+            echo
+            echo '```latex'
+            python3 ../report-build-overhead.py --latex build-overhead.csv
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload Batik workload artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:

--- a/.github/workflows/biojava-aot-cache.yml
+++ b/.github/workflows/biojava-aot-cache.yml
@@ -254,6 +254,23 @@ jobs:
             echo "| tree | \`tree.aot\` | $(du -h tree.aot | awk '{print $1}') |"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Measure build overhead
+        working-directory: biojava-experiment
+        run: |
+          chmod +x measure-build-overhead.sh
+          ./measure-build-overhead.sh
+
+      - name: Append build overhead table to summary
+        working-directory: biojava-experiment
+        run: |
+          {
+            echo "## Build overhead (baseline vs. cache production)"
+            echo
+            echo '```latex'
+            python3 ../report-build-overhead.py --latex build-overhead.csv
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       # ── upload ─────────────────────────────────────────────────────────────
 
       - name: Upload BioJava workload artifacts

--- a/.github/workflows/commons-compress-aot-cache.yml
+++ b/.github/workflows/commons-compress-aot-cache.yml
@@ -196,6 +196,23 @@ jobs:
             echo
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Measure build overhead
+        working-directory: commons-compress-experiment
+        run: |
+          chmod +x measure-build-overhead.sh
+          ./measure-build-overhead.sh
+
+      - name: Append build overhead table to summary
+        working-directory: commons-compress-experiment
+        run: |
+          {
+            echo "## Build overhead (baseline vs. cache production)"
+            echo
+            echo '```latex'
+            python3 ../report-build-overhead.py --latex build-overhead.csv
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload Commons Compress workload artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:

--- a/.github/workflows/commons-configuration-aot-cache.yml
+++ b/.github/workflows/commons-configuration-aot-cache.yml
@@ -233,6 +233,23 @@ jobs:
             echo
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Measure build overhead
+        working-directory: commons-configuration-experiment
+        run: |
+          chmod +x measure-build-overhead.sh
+          ./measure-build-overhead.sh
+
+      - name: Append build overhead table to summary
+        working-directory: commons-configuration-experiment
+        run: |
+          {
+            echo "## Build overhead (baseline vs. cache production)"
+            echo
+            echo '```latex'
+            python3 ../report-build-overhead.py --latex build-overhead.csv
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload Commons Configuration workload artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:

--- a/.github/workflows/commons-validator-aot-cache.yml
+++ b/.github/workflows/commons-validator-aot-cache.yml
@@ -188,6 +188,23 @@ jobs:
             echo
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Measure build overhead
+        working-directory: commons-validator-experiment
+        run: |
+          chmod +x measure-build-overhead.sh
+          ./measure-build-overhead.sh
+
+      - name: Append build overhead table to summary
+        working-directory: commons-validator-experiment
+        run: |
+          {
+            echo "## Build overhead (baseline vs. cache production)"
+            echo
+            echo '```latex'
+            python3 ../report-build-overhead.py --latex build-overhead.csv
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload Commons Validator workload artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:

--- a/.github/workflows/opennlp-aot-cache.yml
+++ b/.github/workflows/opennlp-aot-cache.yml
@@ -192,6 +192,23 @@ jobs:
             echo "| tree | \`tree.aot\` | $(du -h tree.aot | awk '{print $1}') |"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Measure build overhead
+        working-directory: opennlp-experiment
+        run: |
+          chmod +x measure-build-overhead.sh
+          ./measure-build-overhead.sh
+
+      - name: Append build overhead table to summary
+        working-directory: opennlp-experiment
+        run: |
+          {
+            echo "## Build overhead (baseline vs. cache production)"
+            echo
+            echo '```latex'
+            python3 ../report-build-overhead.py --latex build-overhead.csv
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload OpenNLP Morfologik workload artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:

--- a/.github/workflows/thymeleaf-aot-cache.yml
+++ b/.github/workflows/thymeleaf-aot-cache.yml
@@ -244,6 +244,23 @@ jobs:
 
       # ── upload ─────────────────────────────────────────────────────────────
 
+      - name: Measure build overhead
+        working-directory: thymeleaf-experiment
+        run: |
+          chmod +x measure-build-overhead.sh
+          ./measure-build-overhead.sh
+
+      - name: Append build overhead table to summary
+        working-directory: thymeleaf-experiment
+        run: |
+          {
+            echo "## Build overhead (baseline vs. cache production)"
+            echo
+            echo '```latex'
+            python3 ../report-build-overhead.py --latex build-overhead.csv
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload Thymeleaf workload artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:

--- a/.github/workflows/tika-aot-cache.yml
+++ b/.github/workflows/tika-aot-cache.yml
@@ -301,6 +301,23 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Measure build overhead
+        working-directory: tika-experiment
+        run: |
+          chmod +x measure-build-overhead.sh
+          ./measure-build-overhead.sh
+
+      - name: Append build overhead table to summary
+        working-directory: tika-experiment
+        run: |
+          {
+            echo "## Build overhead (baseline vs. cache production)"
+            echo
+            echo '```latex'
+            python3 ../report-build-overhead.py --latex build-overhead.csv
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:

--- a/batik-experiment/measure-build-overhead.sh
+++ b/batik-experiment/measure-build-overhead.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Measure build-time overhead of tree-combine AOT cache production.
+# Baseline: mvn clean test -P '!tree-merge'  (no cache produced)
+# Cache:    mvn clean test -Ptree-merge       (cache.aot produced per module)
+# Workload: java -jar fat.jar vs java -XX:AOTCacheOutput=... -jar fat.jar
+# Merge:    java -XX:AOTMode=merge ...        (tree.aot assembled)
+# Output:   build-overhead.csv
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+log()  { echo -e "\033[1;32m[$(date '+%H:%M:%S')] $*\033[0m"; }
+info() { echo -e "\033[1;34m  >> $*\033[0m"; }
+
+CSV="build-overhead.csv"
+echo "component,baseline_ms,cache_ms,overhead_pct" > "$CSV"
+log "Output: $CSV"
+log "Java: $(java -version 2>&1 | head -1)"
+
+LAST_MS=0
+timed() {
+    local _s
+    _s=$(date +%s%3N)
+    "$@"
+    LAST_MS=$(( $(date +%s%3N) - _s ))
+}
+
+measure_mvn() {
+    local label="$1" dir="$2"; shift 2
+    local t_base t_cache ovhd
+
+    info "[$label] baseline"
+    rm -f "$dir/cache.aot"
+    timed sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -P '!tree-merge' $* || true"
+    t_base=$LAST_MS
+
+    info "[$label] cache production"
+    rm -f "$dir/cache.aot"
+    timed sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -Ptree-merge $* || true"
+    t_cache=$LAST_MS
+
+    [[ -f "$dir/cache.aot" ]] || log "WARN: $dir/cache.aot not produced"
+    ovhd=$(awk "BEGIN{printf \"%.1f\", 100*($t_cache-$t_base)/$t_base}")
+    echo "$label,$t_base,$t_cache,$ovhd" | tee -a "$CSV"
+}
+
+measure_workload() {
+    local label="$1" aot_out="$2" fat_jar="$3"; shift 3
+    local t_base t_cache ovhd
+
+    [[ -f "$fat_jar" ]] || { log "SKIP $label — fat jar not found: $fat_jar"; return; }
+
+    info "[$label] baseline"
+    timed java "$@" -jar "$fat_jar" || true
+    t_base=$LAST_MS
+
+    info "[$label] cache production"
+    rm -f "$aot_out"
+    timed java "$@" -XX:AOTCacheOutput="$aot_out" -jar "$fat_jar" || true
+    t_cache=$LAST_MS
+
+    [[ -f "$aot_out" ]] || log "WARN: $aot_out not produced"
+    ovhd=$(awk "BEGIN{printf \"%.1f\", 100*($t_cache-$t_base)/$t_base}")
+    echo "$label,$t_base,$t_cache,$ovhd" | tee -a "$CSV"
+}
+
+# ── Components ────────────────────────────────────────────────────────────────
+
+measure_mvn "batik"               "batik/batik-test-old"
+measure_mvn "xmlgraphics-commons" "batik-deps/xmlgraphics-commons"
+measure_mvn "commons-io"          "batik-deps/commons-io"
+
+# Workload-only deps (facade libraries with no test suite)
+measure_workload "commons-logging" \
+    "batik-deps/commons-logging-workload/cache.aot" \
+    "batik-deps/commons-logging-workload/target/commons-logging-workload-fat.jar"
+
+measure_workload "xml-apis" \
+    "batik-deps/xml-apis-workload/cache.aot" \
+    "batik-deps/xml-apis-workload/target/xml-apis-workload-fat.jar"
+
+measure_workload "xml-apis-ext" \
+    "batik-deps/xml-apis-ext-workload/cache.aot" \
+    "batik-deps/xml-apis-ext-workload/target/xml-apis-ext-workload-fat.jar"
+
+# ── Merge step ────────────────────────────────────────────────────────────────
+
+CACHE_PATHS=(
+  "batik/batik-test-old/cache.aot"
+  "batik-deps/xmlgraphics-commons/cache.aot"
+  "batik-deps/commons-io/cache.aot"
+  "batik-deps/commons-logging-workload/cache.aot"
+  "batik-deps/xml-apis-workload/cache.aot"
+  "batik-deps/xml-apis-ext-workload/cache.aot"
+)
+
+FAT_JAR="benchmark/target/benchmark-fat.jar"
+[[ -f "$FAT_JAR" ]] || { log "SKIP merge — fat jar not found: $FAT_JAR"; exit 0; }
+for p in "${CACHE_PATHS[@]}"; do
+  [[ -f "$p" ]] || { log "SKIP merge — missing $p"; exit 0; }
+done
+
+BASE_AOT="${CACHE_PATHS[0]}"
+MERGE_INPUTS="$(IFS=:; echo "${CACHE_PATHS[*]}")"
+
+info "[merge] assembling tree.aot"
+rm -f tree.aot
+timed java -Xlog:aot=info \
+  -Xlog:aot+map=trace,aot+map+oops=trace,aot=warning:file=aot.map:none:filesize=0 \
+  -XX:AOTMode=merge \
+  -Djava.awt.headless=true \
+  -XX:AOTCache="$BASE_AOT" \
+  -XX:AOTMergeInputs="$MERGE_INPUTS" \
+  -XX:AOTCacheOutput=tree.aot \
+  -cp "$FAT_JAR" \
+  -version
+echo "merge,0,$LAST_MS,N/A" | tee -a "$CSV"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+log "=== Summary ==="
+awk -F, 'NR==1{print; next}
+  $1!="merge"{base+=$2; cache+=$3}
+  $1=="merge"{merge=$3}
+  END{
+    printf "total baseline : %d ms\ntotal with-cache: %d ms\noverhead        : %.1f%%\n",
+      base, cache+merge, 100*(cache+merge-base)/base
+  }' "$CSV"

--- a/batik-experiment/measure-build-overhead.sh
+++ b/batik-experiment/measure-build-overhead.sh
@@ -30,6 +30,9 @@ measure_mvn() {
     local label="$1" dir="$2"; shift 2
     local t_base t_cache ovhd
 
+    info "[$label] warmup (populate Maven local repo)"
+    sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -P '!tree-merge' $* || true"
+
     info "[$label] baseline"
     rm -f "$dir/cache.aot"
     timed sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -P '!tree-merge' $* || true"
@@ -50,6 +53,9 @@ measure_workload() {
     local t_base t_cache ovhd
 
     [[ -f "$fat_jar" ]] || { log "SKIP $label — fat jar not found: $fat_jar"; return; }
+
+    info "[$label] warmup (populate filesystem cache)"
+    java "$@" -jar "$fat_jar" || true
 
     info "[$label] baseline"
     timed java "$@" -jar "$fat_jar" || true

--- a/biojava-experiment/measure-build-overhead.sh
+++ b/biojava-experiment/measure-build-overhead.sh
@@ -30,6 +30,9 @@ measure_mvn() {
     local label="$1" dir="$2"; shift 2
     local t_base t_cache ovhd
 
+    info "[$label] warmup (populate Maven local repo)"
+    sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -P '!tree-merge' $* || true"
+
     info "[$label] baseline"
     rm -f "$dir/cache.aot"
     timed sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -P '!tree-merge' $* || true"
@@ -50,6 +53,9 @@ measure_workload() {
     local t_base t_cache ovhd
 
     [[ -f "$fat_jar" ]] || { log "SKIP $label — fat jar not found: $fat_jar"; return; }
+
+    info "[$label] warmup (populate filesystem cache)"
+    java "$@" -jar "$fat_jar" || true
 
     info "[$label] baseline"
     timed java "$@" -jar "$fat_jar" || true

--- a/biojava-experiment/measure-build-overhead.sh
+++ b/biojava-experiment/measure-build-overhead.sh
@@ -31,11 +31,11 @@ measure_mvn() {
     local t_base t_cache ovhd
 
     info "[$label] warmup (populate Maven local repo)"
-    sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -P '!tree-merge' $* || true"
+    sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -DforkCount=1 -DreuseForks=true -P '!tree-merge' $* || true"
 
     info "[$label] baseline"
     rm -f "$dir/cache.aot"
-    timed sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -P '!tree-merge' $* || true"
+    timed sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -DforkCount=1 -DreuseForks=true -P '!tree-merge' $* || true"
     t_base=$LAST_MS
 
     info "[$label] cache production"
@@ -90,7 +90,9 @@ measure_mvn "commons-codec" "biojava-deps/commons-codec"
 # slf4j-api: multi-module repo, only slf4j-api needed
 # Note: slf4j-api's tree-merge profile has <activation><jdk>[17,)</jdk></activation>
 # so '-P !tree-merge' is required to suppress auto-activation in baseline.
-timed sh -c "cd 'biojava-deps/slf4j' && mvn clean test -B -Drat.skip=true -P '!tree-merge' -pl slf4j-api || true"
+info "[slf4j-api] warmup (populate Maven local repo)"
+sh -c "cd 'biojava-deps/slf4j' && mvn clean test -B -Drat.skip=true -DforkCount=1 -DreuseForks=true -P '!tree-merge' -pl slf4j-api || true"
+timed sh -c "cd 'biojava-deps/slf4j' && mvn clean test -B -Drat.skip=true -DforkCount=1 -DreuseForks=true -P '!tree-merge' -pl slf4j-api || true"
 t_base_slf4j=$LAST_MS
 rm -f "biojava-deps/slf4j/slf4j-api/cache.aot"
 timed sh -c "cd 'biojava-deps/slf4j' && mvn clean test -B -Drat.skip=true -Ptree-merge -pl slf4j-api || true"

--- a/biojava-experiment/measure-build-overhead.sh
+++ b/biojava-experiment/measure-build-overhead.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# Measure build-time overhead of tree-combine AOT cache production.
+# Baseline: mvn clean test -P '!tree-merge'  (no cache produced)
+# Cache:    mvn clean test -Ptree-merge       (cache.aot produced per module)
+# Workload: java -jar fat.jar vs java -XX:AOTCacheOutput=... -jar fat.jar
+# Merge:    java -XX:AOTMode=merge ...        (tree.aot assembled)
+# Output:   build-overhead.csv
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+log()  { echo -e "\033[1;32m[$(date '+%H:%M:%S')] $*\033[0m"; }
+info() { echo -e "\033[1;34m  >> $*\033[0m"; }
+
+CSV="build-overhead.csv"
+echo "component,baseline_ms,cache_ms,overhead_pct" > "$CSV"
+log "Output: $CSV"
+log "Java: $(java -version 2>&1 | head -1)"
+
+LAST_MS=0
+timed() {
+    local _s
+    _s=$(date +%s%3N)
+    "$@"
+    LAST_MS=$(( $(date +%s%3N) - _s ))
+}
+
+measure_mvn() {
+    local label="$1" dir="$2"; shift 2
+    local t_base t_cache ovhd
+
+    info "[$label] baseline"
+    rm -f "$dir/cache.aot"
+    timed sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -P '!tree-merge' $* || true"
+    t_base=$LAST_MS
+
+    info "[$label] cache production"
+    rm -f "$dir/cache.aot"
+    timed sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -Ptree-merge $* || true"
+    t_cache=$LAST_MS
+
+    [[ -f "$dir/cache.aot" ]] || log "WARN: $dir/cache.aot not produced"
+    ovhd=$(awk "BEGIN{printf \"%.1f\", 100*($t_cache-$t_base)/$t_base}")
+    echo "$label,$t_base,$t_cache,$ovhd" | tee -a "$CSV"
+}
+
+measure_workload() {
+    local label="$1" aot_out="$2" fat_jar="$3"; shift 3
+    local t_base t_cache ovhd
+
+    [[ -f "$fat_jar" ]] || { log "SKIP $label — fat jar not found: $fat_jar"; return; }
+
+    info "[$label] baseline"
+    timed java "$@" -jar "$fat_jar" || true
+    t_base=$LAST_MS
+
+    info "[$label] cache production"
+    rm -f "$aot_out"
+    timed java "$@" -XX:AOTCacheOutput="$aot_out" -jar "$fat_jar" || true
+    t_cache=$LAST_MS
+
+    [[ -f "$aot_out" ]] || log "WARN: $aot_out not produced"
+    ovhd=$(awk "BEGIN{printf \"%.1f\", 100*($t_cache-$t_base)/$t_base}")
+    echo "$label,$t_base,$t_cache,$ovhd" | tee -a "$CSV"
+}
+
+# ── Components ────────────────────────────────────────────────────────────────
+
+# biojava modules (log4j excluded via pom, not a profile flag)
+measure_mvn "biojava-core"      "biojava/biojava-core"
+measure_mvn "biojava-alignment" "biojava/biojava-alignment"
+measure_mvn "biojava-aa-prop"   "biojava/biojava-aa-prop"
+measure_mvn "biojava-structure" "biojava/biojava-structure"
+
+# forester: no usable test suite; custom workload jar
+measure_workload "forester" \
+    "biojava-deps/forester/cache.aot" \
+    "biojava-deps/forester/target/forester-workload-fat.jar"
+
+# commons-codec: forester's dep; has tree-merge profile
+measure_mvn "commons-codec" "biojava-deps/commons-codec"
+
+# slf4j-api: multi-module repo, only slf4j-api needed
+# Note: slf4j-api's tree-merge profile has <activation><jdk>[17,)</jdk></activation>
+# so '-P !tree-merge' is required to suppress auto-activation in baseline.
+timed sh -c "cd 'biojava-deps/slf4j' && mvn clean test -B -Drat.skip=true -P '!tree-merge' -pl slf4j-api || true"
+t_base_slf4j=$LAST_MS
+rm -f "biojava-deps/slf4j/slf4j-api/cache.aot"
+timed sh -c "cd 'biojava-deps/slf4j' && mvn clean test -B -Drat.skip=true -Ptree-merge -pl slf4j-api || true"
+t_cache_slf4j=$LAST_MS
+[[ -f "biojava-deps/slf4j/slf4j-api/cache.aot" ]] || log "WARN: slf4j-api/cache.aot not produced"
+ovhd_slf4j=$(awk "BEGIN{printf \"%.1f\", 100*($t_cache_slf4j-$t_base_slf4j)/$t_base_slf4j}")
+echo "slf4j-api,$t_base_slf4j,$t_cache_slf4j,$ovhd_slf4j" | tee -a "$CSV"
+
+# ── Merge step ────────────────────────────────────────────────────────────────
+
+CACHE_PATHS=(
+  "biojava/biojava-core/cache.aot"
+  "biojava/biojava-alignment/cache.aot"
+  "biojava/biojava-aa-prop/cache.aot"
+  "biojava/biojava-structure/cache.aot"
+  "biojava-deps/forester/cache.aot"
+  "biojava-deps/commons-codec/cache.aot"
+  "biojava-deps/slf4j/slf4j-api/cache.aot"
+)
+
+FAT_JAR="benchmark/target/benchmark-fat.jar"
+[[ -f "$FAT_JAR" ]] || { log "SKIP merge — fat jar not found: $FAT_JAR"; exit 0; }
+for p in "${CACHE_PATHS[@]}"; do
+  [[ -f "$p" ]] || { log "SKIP merge — missing $p"; exit 0; }
+done
+
+BASE_AOT="${CACHE_PATHS[0]}"
+MERGE_INPUTS="$(IFS=:; echo "${CACHE_PATHS[*]}")"
+
+info "[merge] assembling tree.aot"
+rm -f tree.aot
+timed java -Xlog:aot=info \
+  -Xlog:aot+link:file="aotlink-tree-create.log" \
+  -Xlog:aot+map=trace,aot+map+oops=trace,aot=warning:file=aot.map:none:filesize=0 \
+  -XX:AOTMode=merge \
+  -XX:AOTCache="$BASE_AOT" \
+  -XX:AOTMergeInputs="$MERGE_INPUTS" \
+  -XX:AOTCacheOutput=tree.aot \
+  -cp "$FAT_JAR" \
+  -version
+echo "merge,0,$LAST_MS,N/A" | tee -a "$CSV"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+log "=== Summary ==="
+awk -F, 'NR==1{print; next}
+  $1!="merge"{base+=$2; cache+=$3}
+  $1=="merge"{merge=$3}
+  END{
+    printf "total baseline : %d ms\ntotal with-cache: %d ms\noverhead        : %.1f%%\n",
+      base, cache+merge, 100*(cache+merge-base)/base
+  }' "$CSV"

--- a/commons-compress-experiment/measure-build-overhead.sh
+++ b/commons-compress-experiment/measure-build-overhead.sh
@@ -32,6 +32,9 @@ measure_mvn() {
     local label="$1" dir="$2"; shift 2
     local t_base t_cache ovhd
 
+    info "[$label] warmup (populate Maven local repo)"
+    sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -P '!tree-merge' $* || true"
+
     info "[$label] baseline"
     rm -f "$dir/cache.aot"
     timed sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -P '!tree-merge' $* || true"

--- a/commons-compress-experiment/measure-build-overhead.sh
+++ b/commons-compress-experiment/measure-build-overhead.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Measure build-time overhead of tree-combine AOT cache production.
+# Baseline: mvn clean test -P '!tree-merge'  (no cache produced)
+# Cache:    mvn clean test -Ptree-merge       (cache.aot produced per module)
+# Merge:    java -XX:AOTMode=merge ...        (tree.aot assembled)
+# Output:   build-overhead.csv
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+log()  { echo -e "\033[1;32m[$(date '+%H:%M:%S')] $*\033[0m"; }
+info() { echo -e "\033[1;34m  >> $*\033[0m"; }
+
+CSV="build-overhead.csv"
+echo "component,baseline_ms,cache_ms,overhead_pct" > "$CSV"
+log "Output: $CSV"
+log "Java: $(java -version 2>&1 | head -1)"
+
+# Wall-clock timer; stores result in LAST_MS.
+LAST_MS=0
+timed() {
+    local _s
+    _s=$(date +%s%3N)
+    "$@"
+    LAST_MS=$(( $(date +%s%3N) - _s ))
+}
+
+# Measure overhead for a maven module.
+# Usage: measure_mvn <label> <dir> [extra mvn args...]
+measure_mvn() {
+    local label="$1" dir="$2"; shift 2
+    local t_base t_cache ovhd
+
+    info "[$label] baseline"
+    rm -f "$dir/cache.aot"
+    timed sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -P '!tree-merge' $* || true"
+    t_base=$LAST_MS
+
+    info "[$label] cache production"
+    rm -f "$dir/cache.aot"
+    timed sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -Ptree-merge $* || true"
+    t_cache=$LAST_MS
+
+    [[ -f "$dir/cache.aot" ]] || log "WARN: $dir/cache.aot not produced — check for test failures"
+    ovhd=$(awk "BEGIN{printf \"%.1f\", 100*($t_cache-$t_base)/$t_base}")
+    echo "$label,$t_base,$t_cache,$ovhd" | tee -a "$CSV"
+}
+
+# ── Components ────────────────────────────────────────────────────────────────
+
+measure_mvn "commons-lang"  "commons-compress-deps/commons-lang"
+measure_mvn "commons-codec" "commons-compress-deps/commons-codec"
+measure_mvn "commons-io"    "commons-compress-deps/apache-commons-io"
+measure_mvn "commons-compress" "commons-compress"
+
+# ── Merge step ────────────────────────────────────────────────────────────────
+
+CACHE_PATHS=(
+  "commons-compress-deps/commons-lang/cache.aot"
+  "commons-compress-deps/commons-codec/cache.aot"
+  "commons-compress-deps/apache-commons-io/cache.aot"
+  "commons-compress/cache.aot"
+)
+JAR_PATHS=(
+  "commons-compress-deps/commons-lang/target/classes"
+  "commons-compress-deps/commons-codec/target/classes"
+  "commons-compress-deps/apache-commons-io/target/classes"
+  "commons-compress/target/classes"
+)
+
+for p in "${CACHE_PATHS[@]}"; do
+  [[ -f "$p" ]] || { log "SKIP merge — missing $p"; exit 0; }
+done
+
+BASE_AOT="commons-compress/cache.aot"
+MERGE_INPUTS="$(IFS=:; echo "${CACHE_PATHS[*]}")"
+CLASSPATH="$(IFS=:; echo "${JAR_PATHS[*]}")"
+
+info "[merge] assembling tree.aot"
+rm -f tree.aot
+timed java -Xlog:aot \
+  -Xlog:aot=info \
+  -Xlog:aot+map=trace,aot+map+oops=trace,aot=warning:file=aot.map:none:filesize=0 \
+  -XX:AOTMode=merge \
+  --add-modules java.instrument \
+  --add-opens java.base/java.io=ALL-UNNAMED \
+  --add-opens java.base/java.lang=ALL-UNNAMED \
+  --add-opens java.base/java.lang.reflect=ALL-UNNAMED \
+  --add-opens java.base/java.time=ALL-UNNAMED \
+  --add-opens java.base/java.time.chrono=ALL-UNNAMED \
+  --add-opens java.base/java.util=ALL-UNNAMED \
+  -XX:AOTCache="$BASE_AOT" \
+  -XX:AOTMergeInputs="$MERGE_INPUTS" \
+  -XX:AOTCacheOutput=tree.aot \
+  -cp "$CLASSPATH" \
+  -version
+echo "merge,0,$LAST_MS,N/A" | tee -a "$CSV"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+log "=== Summary ==="
+awk -F, 'NR==1{print; next}
+  $1!="merge"{base+=$2; cache+=$3}
+  $1=="merge"{merge=$3}
+  END{
+    total_base=base; total_cache=cache+merge;
+    printf "total baseline : %d ms\ntotal with-cache: %d ms\noverhead        : %.1f%%\n",
+      total_base, total_cache, 100*(total_cache-total_base)/total_base
+  }' "$CSV"

--- a/commons-configuration-experiment/measure-build-overhead.sh
+++ b/commons-configuration-experiment/measure-build-overhead.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# Measure build-time overhead of tree-combine AOT cache production.
+# Baseline: mvn clean test -P '!tree-merge'  (no cache produced)
+# Cache:    mvn clean test -Ptree-merge       (cache.aot produced per module)
+# Workload: java -jar fat.jar vs java -XX:AOTCacheOutput=... -jar fat.jar
+# Merge:    java -XX:AOTMode=merge ...        (tree.aot assembled)
+# Output:   build-overhead.csv
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+log()  { echo -e "\033[1;32m[$(date '+%H:%M:%S')] $*\033[0m"; }
+info() { echo -e "\033[1;34m  >> $*\033[0m"; }
+
+CSV="build-overhead.csv"
+echo "component,baseline_ms,cache_ms,overhead_pct" > "$CSV"
+log "Output: $CSV"
+log "Java: $(java -version 2>&1 | head -1)"
+
+LAST_MS=0
+timed() {
+    local _s
+    _s=$(date +%s%3N)
+    "$@"
+    LAST_MS=$(( $(date +%s%3N) - _s ))
+}
+
+measure_mvn() {
+    local label="$1" dir="$2"; shift 2
+    local t_base t_cache ovhd
+
+    info "[$label] baseline"
+    rm -f "$dir/cache.aot"
+    timed sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -P '!tree-merge' $* || true"
+    t_base=$LAST_MS
+
+    info "[$label] cache production"
+    rm -f "$dir/cache.aot"
+    timed sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -Ptree-merge $* || true"
+    t_cache=$LAST_MS
+
+    [[ -f "$dir/cache.aot" ]] || log "WARN: $dir/cache.aot not produced"
+    ovhd=$(awk "BEGIN{printf \"%.1f\", 100*($t_cache-$t_base)/$t_base}")
+    echo "$label,$t_base,$t_cache,$ovhd" | tee -a "$CSV"
+}
+
+# Workload-only component (no test suite — just time the java command).
+# Usage: measure_workload <label> <aot_out_path> <fat_jar> [extra_java_args...]
+measure_workload() {
+    local label="$1" aot_out="$2" fat_jar="$3"; shift 3
+    local t_base t_cache ovhd
+
+    [[ -f "$fat_jar" ]] || { log "SKIP $label — fat jar not found: $fat_jar"; return; }
+
+    info "[$label] baseline"
+    timed java "$@" -jar "$fat_jar" || true
+    t_base=$LAST_MS
+
+    info "[$label] cache production"
+    rm -f "$aot_out"
+    timed java "$@" -XX:AOTCacheOutput="$aot_out" -jar "$fat_jar" || true
+    t_cache=$LAST_MS
+
+    [[ -f "$aot_out" ]] || log "WARN: $aot_out not produced"
+    ovhd=$(awk "BEGIN{printf \"%.1f\", 100*($t_cache-$t_base)/$t_base}")
+    echo "$label,$t_base,$t_cache,$ovhd" | tee -a "$CSV"
+}
+
+# ── Components ────────────────────────────────────────────────────────────────
+
+measure_mvn "commons-lang"        "commons-configuration-deps/commons-lang"
+measure_mvn "commons-text"        "commons-configuration-deps/commons-text"
+measure_mvn "commons-beanutils"   "commons-configuration-deps/commons-beanutils"
+measure_mvn "commons-collections" "commons-configuration-deps/commons-collections"
+
+# commons-logging: no test suite; use workload jar
+LOGGING_DIR="commons-configuration-deps/commons-logging-workload"
+LOGGING_JAR="$LOGGING_DIR/target/commons-logging-workload-1.0-SNAPSHOT.jar"
+LOGGING_AOT="$LOGGING_DIR/cache.aot"
+measure_workload "commons-logging" "$LOGGING_AOT" "$LOGGING_JAR"
+
+measure_mvn "commons-configuration" "commons-configuration"
+
+# ── Merge step ────────────────────────────────────────────────────────────────
+
+CACHE_PATHS=(
+    "commons-configuration-deps/commons-lang/cache.aot"
+    "commons-configuration-deps/commons-text/cache.aot"
+    "commons-configuration-deps/commons-beanutils/cache.aot"
+    "commons-configuration-deps/commons-collections/cache.aot"
+    "$LOGGING_AOT"
+    "commons-configuration/cache.aot"
+)
+CP_ENTRIES=(
+    "commons-configuration-deps/commons-lang/target/classes"
+    "commons-configuration-deps/commons-text/target/classes"
+    "commons-configuration-deps/commons-beanutils/target/classes"
+    "commons-configuration-deps/commons-collections/target/classes"
+    "$LOGGING_JAR"
+    "commons-configuration/target/classes"
+)
+
+for p in "${CACHE_PATHS[@]}"; do
+  [[ -f "$p" ]] || { log "SKIP merge — missing $p"; exit 0; }
+done
+
+BASE_AOT="commons-configuration/cache.aot"
+MERGE_INPUTS="$(IFS=:; echo "${CACHE_PATHS[*]}")"
+CLASSPATH="$(IFS=:; echo "${CP_ENTRIES[*]}")"
+
+info "[merge] assembling tree.aot"
+rm -f tree.aot
+timed java -Xlog:aot \
+    -Xlog:aot=info \
+    -Xlog:aot+map=trace,aot+map+oops=trace,aot=warning:file=aot.map:none:filesize=0 \
+    -XX:AOTMode=merge \
+    --add-opens java.base/java.io=ALL-UNNAMED \
+    --add-opens java.base/java.lang=ALL-UNNAMED \
+    --add-opens java.base/java.lang.reflect=ALL-UNNAMED \
+    --add-opens java.base/java.time=ALL-UNNAMED \
+    --add-opens java.base/java.time.chrono=ALL-UNNAMED \
+    --add-opens java.base/java.util=ALL-UNNAMED \
+    -XX:AOTCache="$BASE_AOT" \
+    -XX:AOTMergeInputs="$MERGE_INPUTS" \
+    -XX:AOTCacheOutput=tree.aot \
+    -cp "$CLASSPATH" \
+    -version
+echo "merge,0,$LAST_MS,N/A" | tee -a "$CSV"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+log "=== Summary ==="
+awk -F, 'NR==1{print; next}
+  $1!="merge"{base+=$2; cache+=$3}
+  $1=="merge"{merge=$3}
+  END{
+    printf "total baseline : %d ms\ntotal with-cache: %d ms\noverhead        : %.1f%%\n",
+      base, cache+merge, 100*(cache+merge-base)/base
+  }' "$CSV"

--- a/commons-configuration-experiment/measure-build-overhead.sh
+++ b/commons-configuration-experiment/measure-build-overhead.sh
@@ -30,6 +30,9 @@ measure_mvn() {
     local label="$1" dir="$2"; shift 2
     local t_base t_cache ovhd
 
+    info "[$label] warmup (populate Maven local repo)"
+    sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -P '!tree-merge' $* || true"
+
     info "[$label] baseline"
     rm -f "$dir/cache.aot"
     timed sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -P '!tree-merge' $* || true"
@@ -52,6 +55,9 @@ measure_workload() {
     local t_base t_cache ovhd
 
     [[ -f "$fat_jar" ]] || { log "SKIP $label — fat jar not found: $fat_jar"; return; }
+
+    info "[$label] warmup (populate filesystem cache)"
+    java "$@" -jar "$fat_jar" || true
 
     info "[$label] baseline"
     timed java "$@" -jar "$fat_jar" || true

--- a/commons-validator-experiment/measure-build-overhead.sh
+++ b/commons-validator-experiment/measure-build-overhead.sh
@@ -36,6 +36,9 @@ measure_mvn() {
     local label="$1" dir="$2"; shift 2
     local t_base t_cache ovhd
 
+    info "[$label] warmup (populate Maven local repo)"
+    sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -P '!tree-merge' $* || true"
+
     info "[$label] baseline"
     rm -f "$dir/cache.aot"
     timed sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -P '!tree-merge' $* || true"
@@ -56,6 +59,9 @@ measure_workload() {
     local t_base t_cache ovhd
 
     [[ -f "$fat_jar" ]] || { log "SKIP $label — fat jar not found: $fat_jar"; return; }
+
+    info "[$label] warmup (populate filesystem cache)"
+    java "$@" -jar "$fat_jar" || true
 
     info "[$label] baseline"
     timed java "$@" -jar "$fat_jar" || true

--- a/commons-validator-experiment/measure-build-overhead.sh
+++ b/commons-validator-experiment/measure-build-overhead.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+# Measure build-time overhead of tree-combine AOT cache production.
+# Baseline: mvn clean test -P '!tree-merge'  (no cache produced)
+# Cache:    mvn clean test -Ptree-merge       (cache.aot produced per module)
+# Workload: java -jar fat.jar vs java -XX:AOTCacheOutput=... -jar fat.jar
+# Merge:    java -XX:AOTMode=merge ...        (tree.aot assembled)
+# Output:   build-overhead.csv
+#
+# NOTE: commons-validator-deps/commons-logging is a git submodule.
+# It must be checked out to branch 'aotcache-setup-commons-validator' of
+# algomaster99/commons-logging (currently on 'fop-experiment' by mistake).
+# Run: git submodule update --remote commons-validator-deps/commons-logging
+# or:  git -C commons-validator-deps/commons-logging checkout aotcache-setup-commons-validator
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+log()  { echo -e "\033[1;32m[$(date '+%H:%M:%S')] $*\033[0m"; }
+info() { echo -e "\033[1;34m  >> $*\033[0m"; }
+
+CSV="build-overhead.csv"
+echo "component,baseline_ms,cache_ms,overhead_pct" > "$CSV"
+log "Output: $CSV"
+log "Java: $(java -version 2>&1 | head -1)"
+
+LAST_MS=0
+timed() {
+    local _s
+    _s=$(date +%s%3N)
+    "$@"
+    LAST_MS=$(( $(date +%s%3N) - _s ))
+}
+
+measure_mvn() {
+    local label="$1" dir="$2"; shift 2
+    local t_base t_cache ovhd
+
+    info "[$label] baseline"
+    rm -f "$dir/cache.aot"
+    timed sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -P '!tree-merge' $* || true"
+    t_base=$LAST_MS
+
+    info "[$label] cache production"
+    rm -f "$dir/cache.aot"
+    timed sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -Ptree-merge $* || true"
+    t_cache=$LAST_MS
+
+    [[ -f "$dir/cache.aot" ]] || log "WARN: $dir/cache.aot not produced"
+    ovhd=$(awk "BEGIN{printf \"%.1f\", 100*($t_cache-$t_base)/$t_base}")
+    echo "$label,$t_base,$t_cache,$ovhd" | tee -a "$CSV"
+}
+
+measure_workload() {
+    local label="$1" aot_out="$2" fat_jar="$3"; shift 3
+    local t_base t_cache ovhd
+
+    [[ -f "$fat_jar" ]] || { log "SKIP $label — fat jar not found: $fat_jar"; return; }
+
+    info "[$label] baseline"
+    timed java "$@" -jar "$fat_jar" || true
+    t_base=$LAST_MS
+
+    info "[$label] cache production"
+    rm -f "$aot_out"
+    timed java "$@" -XX:AOTCacheOutput="$aot_out" -jar "$fat_jar" || true
+    t_cache=$LAST_MS
+
+    [[ -f "$aot_out" ]] || log "WARN: $aot_out not produced"
+    ovhd=$(awk "BEGIN{printf \"%.1f\", 100*($t_cache-$t_base)/$t_base}")
+    echo "$label,$t_base,$t_cache,$ovhd" | tee -a "$CSV"
+}
+
+# ── Components ────────────────────────────────────────────────────────────────
+
+measure_mvn "commons-beanutils"   "commons-validator-deps/commons-beanutils"
+measure_mvn "commons-digester"    "commons-validator-deps/commons-digester"
+
+# commons-logging: facade with no test suite — measure java command overhead.
+# The submodule must be on branch aotcache-setup-commons-validator.
+# Adjust the fat jar name below once the correct branch is checked out.
+LOGGING_DIR="commons-validator-deps/commons-logging"
+LOGGING_AOT="$LOGGING_DIR/cache.aot"
+# Try common fat-jar naming conventions
+for _jar in \
+    "$LOGGING_DIR/target/commons-logging-workload-fat.jar" \
+    "$LOGGING_DIR/target/commons-logging-workload-1.0-SNAPSHOT.jar"; do
+    if [[ -f "$_jar" ]]; then
+        LOGGING_JAR="$_jar"
+        break
+    fi
+done
+if [[ -z "${LOGGING_JAR:-}" ]]; then
+    log "SKIP commons-logging — fat jar not found (submodule on wrong branch?)"
+else
+    measure_workload "commons-logging" "$LOGGING_AOT" "$LOGGING_JAR"
+fi
+
+measure_mvn "commons-collections" "commons-validator-deps/commons-collections"
+measure_mvn "commons-validator"   "commons-validator"
+
+# ── Merge step ────────────────────────────────────────────────────────────────
+
+CACHE_PATHS=(
+  "commons-validator-deps/commons-beanutils/cache.aot"
+  "commons-validator-deps/commons-digester/cache.aot"
+  "$LOGGING_AOT"
+  "commons-validator-deps/commons-collections/cache.aot"
+  "commons-validator/cache.aot"
+)
+JAR_PATHS=(
+  "commons-validator-deps/commons-beanutils/target/classes"
+  "commons-validator-deps/commons-digester/target/classes"
+  "commons-validator-deps/commons-logging/target/classes"
+  "commons-validator-deps/commons-collections/target/classes"
+  "commons-validator/target/classes"
+)
+
+for p in "${CACHE_PATHS[@]}"; do
+  [[ -f "$p" ]] || { log "SKIP merge — missing $p"; exit 0; }
+done
+for p in "${JAR_PATHS[@]}"; do
+  [[ -e "$p" ]] || { log "SKIP merge — missing $p"; exit 0; }
+done
+
+BASE_AOT="commons-validator/cache.aot"
+MERGE_INPUTS="$(IFS=:; echo "${CACHE_PATHS[*]}")"
+CLASSPATH="$(IFS=:; echo "${JAR_PATHS[*]}")"
+
+info "[merge] assembling tree.aot"
+rm -f tree.aot
+timed java -Xlog:aot \
+  -Xlog:aot=info \
+  -Xlog:aot+link:file="aotlink-tree-create.log" \
+  -XX:AOTMode=merge \
+  --add-modules java.instrument \
+  --add-opens java.base/java.io=ALL-UNNAMED \
+  --add-opens java.base/java.lang=ALL-UNNAMED \
+  --add-opens java.base/java.lang.reflect=ALL-UNNAMED \
+  --add-opens java.base/java.time=ALL-UNNAMED \
+  --add-opens java.base/java.time.chrono=ALL-UNNAMED \
+  --add-opens java.base/java.util=ALL-UNNAMED \
+  -XX:AOTCache="$BASE_AOT" \
+  -XX:AOTMergeInputs="$MERGE_INPUTS" \
+  -XX:AOTCacheOutput=tree.aot \
+  -cp "$CLASSPATH" \
+  -version
+echo "merge,0,$LAST_MS,N/A" | tee -a "$CSV"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+log "=== Summary ==="
+awk -F, 'NR==1{print; next}
+  $1!="merge"{base+=$2; cache+=$3}
+  $1=="merge"{merge=$3}
+  END{
+    printf "total baseline : %d ms\ntotal with-cache: %d ms\noverhead        : %.1f%%\n",
+      base, cache+merge, 100*(cache+merge-base)/base
+  }' "$CSV"

--- a/opennlp-experiment/measure-build-overhead.sh
+++ b/opennlp-experiment/measure-build-overhead.sh
@@ -32,6 +32,9 @@ measure_mvn() {
     local label="$1" dir="$2"; shift 2
     local t_base t_cache ovhd
 
+    info "[$label] warmup (populate Maven local repo)"
+    sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -P '!tree-merge' $* || true"
+
     info "[$label] baseline"
     rm -f "$dir/cache.aot"
     timed sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -P '!tree-merge' $* || true"

--- a/opennlp-experiment/measure-build-overhead.sh
+++ b/opennlp-experiment/measure-build-overhead.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# Measure build-time overhead of tree-combine AOT cache production.
+# Baseline: mvn clean test -P '!tree-merge'  (no cache produced)
+# Cache:    mvn clean test -Ptree-merge       (cache.aot produced per module)
+# Merge:    java -XX:AOTMode=merge ...        (tree.aot assembled)
+# Output:   build-overhead.csv
+#
+# Prerequisite: run 'mvn install -DskipTests' in opennlp/ and opennlp-deps/morfologik/
+# before running this script so inter-module dependencies are in the local Maven repo.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+log()  { echo -e "\033[1;32m[$(date '+%H:%M:%S')] $*\033[0m"; }
+info() { echo -e "\033[1;34m  >> $*\033[0m"; }
+
+CSV="build-overhead.csv"
+echo "component,baseline_ms,cache_ms,overhead_pct" > "$CSV"
+log "Output: $CSV"
+log "Java: $(java -version 2>&1 | head -1)"
+
+LAST_MS=0
+timed() {
+    local _s
+    _s=$(date +%s%3N)
+    "$@"
+    LAST_MS=$(( $(date +%s%3N) - _s ))
+}
+
+measure_mvn() {
+    local label="$1" dir="$2"; shift 2
+    local t_base t_cache ovhd
+
+    info "[$label] baseline"
+    rm -f "$dir/cache.aot"
+    timed sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -P '!tree-merge' $* || true"
+    t_base=$LAST_MS
+
+    info "[$label] cache production"
+    rm -f "$dir/cache.aot"
+    timed sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -Ptree-merge $* || true"
+    t_cache=$LAST_MS
+
+    [[ -f "$dir/cache.aot" ]] || log "WARN: $dir/cache.aot not produced"
+    ovhd=$(awk "BEGIN{printf \"%.1f\", 100*($t_cache-$t_base)/$t_base}")
+    echo "$label,$t_base,$t_cache,$ovhd" | tee -a "$CSV"
+}
+
+OPENNLP_DIR="opennlp"
+MORFOLOGIK_DIR="opennlp-deps/morfologik"
+
+# ── Components ────────────────────────────────────────────────────────────────
+
+measure_mvn "opennlp-tools"          "$OPENNLP_DIR/opennlp-tools"
+measure_mvn "opennlp-morfologik"     "$OPENNLP_DIR/opennlp-morfologik-addon"
+measure_mvn "morfologik-fsa-builders" "$MORFOLOGIK_DIR/morfologik-fsa-builders"
+measure_mvn "morfologik-stemming"    "$MORFOLOGIK_DIR/morfologik-stemming"
+measure_mvn "morfologik-tools"       "$MORFOLOGIK_DIR/morfologik-tools"
+
+# ── Merge step ────────────────────────────────────────────────────────────────
+
+OPENNLP_MODULES=(opennlp-tools opennlp-morfologik-addon)
+MORFOLOGIK_MODULES=(morfologik-fsa-builders morfologik-stemming morfologik-tools)
+
+CACHE_PATHS=()
+CLASSES_PATHS=()
+for mod in "${OPENNLP_MODULES[@]}"; do
+  CACHE_PATHS+=("$OPENNLP_DIR/$mod/cache.aot")
+  CLASSES_PATHS+=("$OPENNLP_DIR/$mod/target/classes")
+done
+for mod in "${MORFOLOGIK_MODULES[@]}"; do
+  CACHE_PATHS+=("$MORFOLOGIK_DIR/$mod/cache.aot")
+  CLASSES_PATHS+=("$MORFOLOGIK_DIR/$mod/target/classes")
+done
+
+for p in "${CACHE_PATHS[@]}"; do
+  [[ -f "$p" ]] || { log "SKIP merge — missing $p"; exit 0; }
+done
+
+# Recompile if target/classes was cleaned
+NEED_COMPILE=false
+for p in "${CLASSES_PATHS[@]}"; do [[ -d "$p" ]] || { NEED_COMPILE=true; break; }; done
+if $NEED_COMPILE; then
+    log "Recompiling (target/classes missing after clean)..."
+    (cd "$OPENNLP_DIR" && mvn -q -B compile -pl "$(IFS=,; echo "${OPENNLP_MODULES[*]}")" --also-make)
+    (cd "$MORFOLOGIK_DIR" && mvn -q -B compile -pl "$(IFS=,; echo "${MORFOLOGIK_MODULES[*]}")" --also-make)
+fi
+
+DEPS_DIR="${SCRIPT_DIR}/combine-deps"
+mkdir -p "$DEPS_DIR"
+(cd "$OPENNLP_DIR" && mvn -q -B dependency:copy-dependencies \
+  -DoutputDirectory="$DEPS_DIR" -DincludeScope=compile \
+  -DexcludeGroupIds=org.apache.opennlp \
+  -pl "$(IFS=,; echo "${OPENNLP_MODULES[*]}")" 2>/dev/null)
+(cd "$MORFOLOGIK_DIR" && mvn -q -B dependency:copy-dependencies \
+  -DoutputDirectory="$DEPS_DIR" -DincludeScope=compile \
+  -DexcludeGroupIds=org.carrot2 \
+  -pl "$(IFS=,; echo "${MORFOLOGIK_MODULES[*]}")" 2>/dev/null)
+
+DEP_CP="$(find "$DEPS_DIR" -name '*.jar' | sort | tr '\n' ':' | sed 's/:$//')"
+CLASSES_CP="$(IFS=:; echo "${CLASSES_PATHS[*]}")"
+CLASSPATH="${CLASSES_CP}:${DEP_CP}"
+
+BASE_AOT="${CACHE_PATHS[0]}"
+MERGE_INPUTS="$(IFS=:; echo "${CACHE_PATHS[*]}")"
+
+info "[merge] assembling tree.aot"
+rm -f tree.aot
+timed java \
+  -Xlog:aot=info \
+  -Xlog:aot+map=trace,aot+map+oops=trace,aot=warning:file=aot.map:none:filesize=0 \
+  --add-opens java.base/java.io=ALL-UNNAMED \
+  --add-opens java.base/java.lang=ALL-UNNAMED \
+  --add-opens java.base/java.lang.reflect=ALL-UNNAMED \
+  --add-opens java.base/java.util=ALL-UNNAMED \
+  --add-opens java.base/jdk.internal.loader=ALL-UNNAMED \
+  -XX:AOTMode=merge \
+  -XX:AOTCache="$BASE_AOT" \
+  -XX:AOTMergeInputs="$MERGE_INPUTS" \
+  -XX:AOTCacheOutput=tree.aot \
+  -cp "$CLASSPATH" \
+  -version
+echo "merge,0,$LAST_MS,N/A" | tee -a "$CSV"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+log "=== Summary ==="
+awk -F, 'NR==1{print; next}
+  $1!="merge"{base+=$2; cache+=$3}
+  $1=="merge"{merge=$3}
+  END{
+    printf "total baseline : %d ms\ntotal with-cache: %d ms\noverhead        : %.1f%%\n",
+      base, cache+merge, 100*(cache+merge-base)/base
+  }' "$CSV"

--- a/report-build-overhead.py
+++ b/report-build-overhead.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Print build-overhead.csv as a terminal table or LaTeX tabular.
+
+Usage:
+  python3 report-build-overhead.py [build-overhead.csv]
+  python3 report-build-overhead.py --latex [build-overhead.csv]
+
+The CSV is produced by measure-build-overhead.sh in each experiment directory.
+Columns: component, baseline_ms, cache_ms, overhead_pct
+"""
+import csv, sys, argparse, os
+
+parser = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+parser.add_argument('csv_file', nargs='?', default='build-overhead.csv')
+parser.add_argument('--latex', action='store_true', help='emit LaTeX tabular instead')
+args = parser.parse_args()
+
+if not os.path.exists(args.csv_file):
+    print(f'ERROR: {args.csv_file} not found — run measure-build-overhead.sh first', file=sys.stderr)
+    sys.exit(1)
+
+with open(args.csv_file) as f:
+    rows = list(csv.DictReader(f))
+
+def ms_to_s(ms_str):
+    return int(ms_str) / 1000
+
+# Totals (exclude merge row)
+build_rows = [r for r in rows if r['component'] != 'merge']
+merge_rows  = [r for r in rows if r['component'] == 'merge']
+
+total_base  = sum(int(r['baseline_ms']) for r in build_rows)
+total_cache = sum(int(r['cache_ms'])    for r in build_rows)
+merge_ms    = int(merge_rows[0]['cache_ms']) if merge_rows else 0
+total_with_merge = total_cache + merge_ms
+total_overhead   = 100 * (total_with_merge - total_base) / total_base if total_base else 0
+
+if args.latex:
+    print(r'\begin{tabular}{@{}l r r r@{}}')
+    print(r'\toprule')
+    print(r'\textbf{Component} & \textbf{Baseline (s)} & \textbf{Cache prod. (s)} & \textbf{Overhead (\%)} \\')
+    print(r'\midrule')
+    for r in build_rows:
+        base_s  = ms_to_s(r['baseline_ms'])
+        cache_s = ms_to_s(r['cache_ms'])
+        ovhd    = r['overhead_pct']
+        sign    = '+' if float(ovhd) >= 0 else ''
+        print(f"  {r['component']:<28} & {base_s:>8.1f} & {cache_s:>8.1f} & {sign}{ovhd} \\\\")
+    if merge_rows:
+        print(r'\midrule')
+        print(f"  {'merge step':<28} & {'---':>8} & {ms_to_s(merge_rows[0]['cache_ms']):>8.1f} & {'N/A':>6} \\\\")
+    print(r'\midrule')
+    sign = '+' if total_overhead >= 0 else ''
+    print(f"  {'\\textbf{{Total}}':<28} & {total_base/1000:>8.1f} & {total_with_merge/1000:>8.1f} & {sign}{total_overhead:.1f} \\\\")
+    print(r'\bottomrule')
+    print(r'\end{tabular}')
+else:
+    # Terminal table
+    col_w = [max(len('Component'), max(len(r['component']) for r in rows)),
+             max(len('Baseline (s)'), 12),
+             max(len('Cache prod. (s)'), 15),
+             max(len('Overhead (%)'), 12)]
+
+    sep = '+' + '+'.join('-' * (w + 2) for w in col_w) + '+'
+    def row_line(cells):
+        return '| ' + ' | '.join(str(c).ljust(col_w[i]) for i, c in enumerate(cells)) + ' |'
+
+    print(sep)
+    print(row_line(['Component', 'Baseline (s)', 'Cache prod. (s)', 'Overhead (%)']))
+    print(sep)
+    for r in build_rows:
+        base_s  = f"{ms_to_s(r['baseline_ms']):.1f}"
+        cache_s = f"{ms_to_s(r['cache_ms']):.1f}"
+        ovhd    = r['overhead_pct']
+        sign    = '+' if float(ovhd) >= 0 else ''
+        print(row_line([r['component'], base_s, cache_s, f'{sign}{ovhd}%']))
+    if merge_rows:
+        print(sep)
+        print(row_line(['merge step', '---', f"{ms_to_s(merge_rows[0]['cache_ms']):.1f}", 'N/A']))
+    print(sep)
+    sign = '+' if total_overhead >= 0 else ''
+    print(row_line(['TOTAL', f'{total_base/1000:.1f}', f'{total_with_merge/1000:.1f}',
+                    f'{sign}{total_overhead:.1f}%']))
+    print(sep)

--- a/report-build-overhead.py
+++ b/report-build-overhead.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
-"""Print build-overhead.csv as a terminal table or LaTeX tabular.
+"""Print build-overhead CSV(s) as a terminal table or a combined LaTeX table.
 
-Usage:
-  python3 report-build-overhead.py [build-overhead.csv]
-  python3 report-build-overhead.py --latex [build-overhead.csv]
+Usage (terminal, one experiment):
+  python3 report-build-overhead.py build-overhead.csv
+
+Usage (LaTeX, one or more experiments combined):
+  python3 report-build-overhead.py --latex \\
+      batik-experiment/build-overhead.csv \\
+      thymeleaf-experiment/build-overhead.csv
+
+  Optional: --caption TEXT  --label TEXT
 
 The CSV is produced by measure-build-overhead.sh in each experiment directory.
 Columns: component, baseline_ms, cache_ms, overhead_pct
@@ -12,74 +18,107 @@ import csv, sys, argparse, os
 
 parser = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
-parser.add_argument('csv_file', nargs='?', default='build-overhead.csv')
-parser.add_argument('--latex', action='store_true', help='emit LaTeX tabular instead')
+parser.add_argument('csv_files', nargs='+', metavar='CSV')
+parser.add_argument('--latex',   action='store_true', help='emit LaTeX table environment')
+parser.add_argument('--caption', default=r'Build time overhead of \toolname{} cache production.',
+                    help='LaTeX caption text')
+parser.add_argument('--label',   default='tab:rq1-overhead', help='LaTeX label')
 args = parser.parse_args()
 
-if not os.path.exists(args.csv_file):
-    print(f'ERROR: {args.csv_file} not found — run measure-build-overhead.sh first', file=sys.stderr)
-    sys.exit(1)
 
-with open(args.csv_file) as f:
-    rows = list(csv.DictReader(f))
+def load(path):
+    with open(path) as f:
+        return list(csv.DictReader(f))
 
 def ms_to_s(ms_str):
     return int(ms_str) / 1000
 
-# Totals (exclude merge row)
-build_rows = [r for r in rows if r['component'] != 'merge']
-merge_rows  = [r for r in rows if r['component'] == 'merge']
+def group_name(path):
+    """Derive a short group name from a CSV path, e.g. 'batik-experiment/build-overhead.csv' → 'batik'."""
+    d = os.path.basename(os.path.dirname(os.path.abspath(path)))
+    return d.removesuffix('-experiment')
 
-total_base  = sum(int(r['baseline_ms']) for r in build_rows)
-total_cache = sum(int(r['cache_ms'])    for r in build_rows)
-merge_ms    = int(merge_rows[0]['cache_ms']) if merge_rows else 0
-total_with_merge = total_cache + merge_ms
-total_overhead   = 100 * (total_with_merge - total_base) / total_base if total_base else 0
+def fmt_ovhd(ovhd_str):
+    v = float(ovhd_str)
+    sign = '+' if v >= 0 else ''
+    return f'{sign}{ovhd_str}'
+
 
 if args.latex:
+    print(r'\begin{table}[t]')
+    print(r'\centering')
+    print(f'\\caption{{{args.caption}}}')
+    print(f'\\label{{{args.label}}}')
+    print(r'\resizebox{\columnwidth}{!}{%')
     print(r'\begin{tabular}{@{}l r r r@{}}')
     print(r'\toprule')
-    print(r'\textbf{Component} & \textbf{Baseline (s)} & \textbf{Cache prod. (s)} & \textbf{Overhead (\%)} \\')
+    print(r'\textbf{Module} & \textbf{Baseline (s)} & \textbf{Cache prod. (s)} & \textbf{Overhead (\%)} \\')
     print(r'\midrule')
-    for r in build_rows:
-        base_s  = ms_to_s(r['baseline_ms'])
-        cache_s = ms_to_s(r['cache_ms'])
-        ovhd    = r['overhead_pct']
-        sign    = '+' if float(ovhd) >= 0 else ''
-        print(f"  {r['component']:<28} & {base_s:>8.1f} & {cache_s:>8.1f} & {sign}{ovhd} \\\\")
-    if merge_rows:
-        print(r'\midrule')
-        print(f"  {'merge step':<28} & {'---':>8} & {ms_to_s(merge_rows[0]['cache_ms']):>8.1f} & {'N/A':>6} \\\\")
-    print(r'\midrule')
-    sign = '+' if total_overhead >= 0 else ''
-    print(f"  {'\\textbf{{Total}}':<28} & {total_base/1000:>8.1f} & {total_with_merge/1000:>8.1f} & {sign}{total_overhead:.1f} \\\\")
+
+    for i, path in enumerate(args.csv_files):
+        if not os.path.exists(path):
+            print(f'% ERROR: {path} not found', file=sys.stderr)
+            continue
+        rows = load(path)
+        build_rows = [r for r in rows if r['component'] != 'merge']
+        merge_rows  = [r for r in rows if r['component'] == 'merge']
+
+        print(f'\\multicolumn{{4}}{{@{{}}l}}{{\\textit{{{group_name(path)}}}}} \\\\')
+        for r in build_rows:
+            base_s  = f"{ms_to_s(r['baseline_ms']):.1f}"
+            cache_s = f"{ms_to_s(r['cache_ms']):.1f}"
+            print(f"  {r['component']:<24} & {base_s:>7} & {cache_s:>7} & {fmt_ovhd(r['overhead_pct'])} \\\\")
+        if merge_rows:
+            merge_s = f"{ms_to_s(merge_rows[0]['cache_ms']):.1f}"
+            print(f"  {'merge step':<24} & {'---':>7} & {merge_s:>7} & {'N/A'} \\\\")
+
+        if i < len(args.csv_files) - 1:
+            print(r'\midrule')
+
     print(r'\bottomrule')
-    print(r'\end{tabular}')
+    print(r'\end{tabular}%')
+    print(r'}')
+    print(r'\end{table}')
+
 else:
-    # Terminal table
-    col_w = [max(len('Component'), max(len(r['component']) for r in rows)),
-             max(len('Baseline (s)'), 12),
-             max(len('Cache prod. (s)'), 15),
-             max(len('Overhead (%)'), 12)]
+    for path in args.csv_files:
+        if not os.path.exists(path):
+            print(f'ERROR: {path} not found — run measure-build-overhead.sh first', file=sys.stderr)
+            continue
+        rows = load(path)
+        build_rows = [r for r in rows if r['component'] != 'merge']
+        merge_rows  = [r for r in rows if r['component'] == 'merge']
 
-    sep = '+' + '+'.join('-' * (w + 2) for w in col_w) + '+'
-    def row_line(cells):
-        return '| ' + ' | '.join(str(c).ljust(col_w[i]) for i, c in enumerate(cells)) + ' |'
+        total_base        = sum(int(r['baseline_ms']) for r in build_rows)
+        total_cache       = sum(int(r['cache_ms'])    for r in build_rows)
+        merge_ms          = int(merge_rows[0]['cache_ms']) if merge_rows else 0
+        total_with_merge  = total_cache + merge_ms
+        total_overhead    = 100 * (total_with_merge - total_base) / total_base if total_base else 0
 
-    print(sep)
-    print(row_line(['Component', 'Baseline (s)', 'Cache prod. (s)', 'Overhead (%)']))
-    print(sep)
-    for r in build_rows:
-        base_s  = f"{ms_to_s(r['baseline_ms']):.1f}"
-        cache_s = f"{ms_to_s(r['cache_ms']):.1f}"
-        ovhd    = r['overhead_pct']
-        sign    = '+' if float(ovhd) >= 0 else ''
-        print(row_line([r['component'], base_s, cache_s, f'{sign}{ovhd}%']))
-    if merge_rows:
+        col_w = [max(len('Module'), max(len(r['component']) for r in rows)),
+                 max(len('Baseline (s)'), 12),
+                 max(len('Cache prod. (s)'), 15),
+                 max(len('Overhead (%)'), 12)]
+
+        sep = '+' + '+'.join('-' * (w + 2) for w in col_w) + '+'
+        def row_line(cells):
+            return '| ' + ' | '.join(str(c).ljust(col_w[i]) for i, c in enumerate(cells)) + ' |'
+
+        if len(args.csv_files) > 1:
+            print(f'\n=== {group_name(path)} ===')
         print(sep)
-        print(row_line(['merge step', '---', f"{ms_to_s(merge_rows[0]['cache_ms']):.1f}", 'N/A']))
-    print(sep)
-    sign = '+' if total_overhead >= 0 else ''
-    print(row_line(['TOTAL', f'{total_base/1000:.1f}', f'{total_with_merge/1000:.1f}',
-                    f'{sign}{total_overhead:.1f}%']))
-    print(sep)
+        print(row_line(['Module', 'Baseline (s)', 'Cache prod. (s)', 'Overhead (%)']))
+        print(sep)
+        for r in build_rows:
+            print(row_line([r['component'],
+                            f"{ms_to_s(r['baseline_ms']):.1f}",
+                            f"{ms_to_s(r['cache_ms']):.1f}",
+                            f"{fmt_ovhd(r['overhead_pct'])}%"]))
+        if merge_rows:
+            print(sep)
+            print(row_line(['merge step', '---', f"{ms_to_s(merge_rows[0]['cache_ms']):.1f}", 'N/A']))
+        print(sep)
+        sign = '+' if total_overhead >= 0 else ''
+        print(row_line(['TOTAL', f'{total_base/1000:.1f}', f'{total_with_merge/1000:.1f}',
+                        f'{sign}{total_overhead:.1f}%']))
+        print(sep)

--- a/thymeleaf-experiment/measure-build-overhead.sh
+++ b/thymeleaf-experiment/measure-build-overhead.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# Measure build-time overhead of tree-combine AOT cache production.
+# Baseline: mvn clean test -P '!tree-merge'  (no cache produced)
+# Cache:    mvn clean test -Ptree-merge       (cache.aot produced per module)
+# Workload: java -jar fat.jar vs java -XX:AOTCacheOutput=... -jar fat.jar
+# Merge:    java -XX:AOTMode=merge ...        (tree.aot assembled)
+# Output:   build-overhead.csv
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+log()  { echo -e "\033[1;32m[$(date '+%H:%M:%S')] $*\033[0m"; }
+info() { echo -e "\033[1;34m  >> $*\033[0m"; }
+
+CSV="build-overhead.csv"
+echo "component,baseline_ms,cache_ms,overhead_pct" > "$CSV"
+log "Output: $CSV"
+log "Java: $(java -version 2>&1 | head -1)"
+
+LAST_MS=0
+timed() {
+    local _s
+    _s=$(date +%s%3N)
+    "$@"
+    LAST_MS=$(( $(date +%s%3N) - _s ))
+}
+
+measure_mvn() {
+    local label="$1" dir="$2"; shift 2
+    local t_base t_cache ovhd
+
+    info "[$label] baseline"
+    rm -f "$dir/cache.aot"
+    timed sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -P '!tree-merge' $* || true"
+    t_base=$LAST_MS
+
+    info "[$label] cache production"
+    rm -f "$dir/cache.aot"
+    timed sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -Ptree-merge $* || true"
+    t_cache=$LAST_MS
+
+    [[ -f "$dir/cache.aot" ]] || log "WARN: $dir/cache.aot not produced"
+    ovhd=$(awk "BEGIN{printf \"%.1f\", 100*($t_cache-$t_base)/$t_base}")
+    echo "$label,$t_base,$t_cache,$ovhd" | tee -a "$CSV"
+}
+
+measure_workload() {
+    local label="$1" aot_out="$2" fat_jar="$3"; shift 3
+    local t_base t_cache ovhd
+
+    [[ -f "$fat_jar" ]] || { log "SKIP $label — fat jar not found: $fat_jar"; return; }
+
+    info "[$label] baseline"
+    timed java "$@" -jar "$fat_jar" || true
+    t_base=$LAST_MS
+
+    info "[$label] cache production"
+    rm -f "$aot_out"
+    timed java "$@" -XX:AOTCacheOutput="$aot_out" -jar "$fat_jar" || true
+    t_cache=$LAST_MS
+
+    [[ -f "$aot_out" ]] || log "WARN: $aot_out not produced"
+    ovhd=$(awk "BEGIN{printf \"%.1f\", 100*($t_cache-$t_base)/$t_base}")
+    echo "$label,$t_base,$t_cache,$ovhd" | tee -a "$CSV"
+}
+
+# ── Components ────────────────────────────────────────────────────────────────
+
+measure_mvn "thymeleaf"   "thymeleaf/tests/thymeleaf-tests-core"
+measure_mvn "attoparser"  "thymeleaf-deps/attoparser"
+measure_mvn "ognl"        "thymeleaf-deps/ognl"
+
+# slf4j: multi-module repo, only slf4j-api is needed
+# Note: slf4j-api's tree-merge profile has <activation><jdk>[17,)</jdk></activation>
+# so '-P !tree-merge' is required for the baseline to suppress auto-activation.
+timed sh -c "cd 'thymeleaf-deps/slf4j' && mvn clean test -B -Drat.skip=true -P '!tree-merge' -pl slf4j-api || true"
+t_base_slf4j=$LAST_MS
+rm -f "thymeleaf-deps/slf4j/slf4j-api/cache.aot"
+timed sh -c "cd 'thymeleaf-deps/slf4j' && mvn clean test -B -Drat.skip=true -Ptree-merge -pl slf4j-api || true"
+t_cache_slf4j=$LAST_MS
+[[ -f "thymeleaf-deps/slf4j/slf4j-api/cache.aot" ]] || log "WARN: slf4j-api/cache.aot not produced"
+ovhd_slf4j=$(awk "BEGIN{printf \"%.1f\", 100*($t_cache_slf4j-$t_base_slf4j)/$t_base_slf4j}")
+echo "slf4j-api,$t_base_slf4j,$t_cache_slf4j,$ovhd_slf4j" | tee -a "$CSV"
+
+# unbescape: no test suite; use workload jar
+measure_workload "unbescape" \
+    "thymeleaf-deps/unbescape-workload/cache.aot" \
+    "thymeleaf-deps/unbescape-workload/target/unbescape-workload-fat.jar" \
+    --add-opens java.base/java.lang=ALL-UNNAMED \
+    --add-opens java.base/java.util=ALL-UNNAMED
+
+# ── Merge step ────────────────────────────────────────────────────────────────
+
+CACHE_PATHS=(
+  "thymeleaf/tests/thymeleaf-tests-core/cache.aot"
+  "thymeleaf-deps/attoparser/cache.aot"
+  "thymeleaf-deps/ognl/cache.aot"
+  "thymeleaf-deps/slf4j/slf4j-api/cache.aot"
+  "thymeleaf-deps/unbescape-workload/cache.aot"
+)
+
+FAT_JAR="benchmark/target/benchmark-fat.jar"
+[[ -f "$FAT_JAR" ]] || { log "SKIP merge — fat jar not found: $FAT_JAR"; exit 0; }
+for p in "${CACHE_PATHS[@]}"; do
+  [[ -f "$p" ]] || { log "SKIP merge — missing $p"; exit 0; }
+done
+
+BASE_AOT="${CACHE_PATHS[0]}"
+MERGE_INPUTS="$(IFS=:; echo "${CACHE_PATHS[*]}")"
+
+info "[merge] assembling tree.aot"
+rm -f tree.aot
+timed java -Xlog:aot=info \
+  -Xlog:aot+map=trace,aot+map+oops=trace,aot=warning:file=aot.map:none:filesize=0 \
+  --add-opens java.base/java.lang=ALL-UNNAMED \
+  --add-opens java.base/java.util=ALL-UNNAMED \
+  -XX:AOTMode=merge \
+  -XX:AOTCache="$BASE_AOT" \
+  -XX:AOTMergeInputs="$MERGE_INPUTS" \
+  -XX:AOTCacheOutput=tree.aot \
+  -cp "$FAT_JAR" \
+  -version
+echo "merge,0,$LAST_MS,N/A" | tee -a "$CSV"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+log "=== Summary ==="
+awk -F, 'NR==1{print; next}
+  $1!="merge"{base+=$2; cache+=$3}
+  $1=="merge"{merge=$3}
+  END{
+    printf "total baseline : %d ms\ntotal with-cache: %d ms\noverhead        : %.1f%%\n",
+      base, cache+merge, 100*(cache+merge-base)/base
+  }' "$CSV"

--- a/thymeleaf-experiment/measure-build-overhead.sh
+++ b/thymeleaf-experiment/measure-build-overhead.sh
@@ -30,6 +30,9 @@ measure_mvn() {
     local label="$1" dir="$2"; shift 2
     local t_base t_cache ovhd
 
+    info "[$label] warmup (populate Maven local repo)"
+    sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -P '!tree-merge' $* || true"
+
     info "[$label] baseline"
     rm -f "$dir/cache.aot"
     timed sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -P '!tree-merge' $* || true"
@@ -50,6 +53,9 @@ measure_workload() {
     local t_base t_cache ovhd
 
     [[ -f "$fat_jar" ]] || { log "SKIP $label — fat jar not found: $fat_jar"; return; }
+
+    info "[$label] warmup (populate filesystem cache)"
+    java "$@" -jar "$fat_jar" || true
 
     info "[$label] baseline"
     timed java "$@" -jar "$fat_jar" || true

--- a/thymeleaf-experiment/measure-build-overhead.sh
+++ b/thymeleaf-experiment/measure-build-overhead.sh
@@ -80,7 +80,10 @@ measure_mvn "ognl"        "thymeleaf-deps/ognl"
 # slf4j: multi-module repo, only slf4j-api is needed
 # Note: slf4j-api's tree-merge profile has <activation><jdk>[17,)</jdk></activation>
 # so '-P !tree-merge' is required for the baseline to suppress auto-activation.
-timed sh -c "cd 'thymeleaf-deps/slf4j' && mvn clean test -B -Drat.skip=true -P '!tree-merge' -pl slf4j-api || true"
+# slf4j parent POM defaults reuseForks=false; match tree-merge behaviour with -DreuseForks=true.
+info "[slf4j-api] warmup (populate Maven local repo)"
+sh -c "cd 'thymeleaf-deps/slf4j' && mvn clean test -B -Drat.skip=true -DforkCount=1 -DreuseForks=true -P '!tree-merge' -pl slf4j-api || true"
+timed sh -c "cd 'thymeleaf-deps/slf4j' && mvn clean test -B -Drat.skip=true -DforkCount=1 -DreuseForks=true -P '!tree-merge' -pl slf4j-api || true"
 t_base_slf4j=$LAST_MS
 rm -f "thymeleaf-deps/slf4j/slf4j-api/cache.aot"
 timed sh -c "cd 'thymeleaf-deps/slf4j' && mvn clean test -B -Drat.skip=true -Ptree-merge -pl slf4j-api || true"

--- a/tika-experiment/measure-build-overhead.sh
+++ b/tika-experiment/measure-build-overhead.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Measure build-time overhead of tree-combine AOT cache production.
+# Baseline: mvn clean test -P '!tree-merge'  (no cache produced)
+# Cache:    mvn clean test -Ptree-merge       (cache.aot produced per module)
+# Merge:    java -XX:AOTMode=merge ...        (tree.aot assembled)
+# Output:   build-overhead.csv
+#
+# Prerequisite: run 'mvn install -DskipTests' in tika/ before running this
+# script so inter-module dependencies are in the local Maven repo.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+log()  { echo -e "\033[1;32m[$(date '+%H:%M:%S')] $*\033[0m"; }
+info() { echo -e "\033[1;34m  >> $*\033[0m"; }
+
+CSV="build-overhead.csv"
+echo "component,baseline_ms,cache_ms,overhead_pct" > "$CSV"
+log "Output: $CSV"
+log "Java: $(java -version 2>&1 | head -1)"
+
+LAST_MS=0
+timed() {
+    local _s
+    _s=$(date +%s%3N)
+    "$@"
+    LAST_MS=$(( $(date +%s%3N) - _s ))
+}
+
+measure_mvn() {
+    local label="$1" dir="$2"; shift 2
+    local t_base t_cache ovhd
+
+    info "[$label] baseline"
+    rm -f "$dir/cache.aot"
+    timed sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -P '!tree-merge' $* || true"
+    t_base=$LAST_MS
+
+    info "[$label] cache production"
+    rm -f "$dir/cache.aot"
+    timed sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -Ptree-merge $* || true"
+    t_cache=$LAST_MS
+
+    [[ -f "$dir/cache.aot" ]] || log "WARN: $dir/cache.aot not produced"
+    ovhd=$(awk "BEGIN{printf \"%.1f\", 100*($t_cache-$t_base)/$t_base}")
+    echo "$label,$t_base,$t_cache,$ovhd" | tee -a "$CSV"
+}
+
+TIKA_PARSERS="tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules"
+
+# ── Components ────────────────────────────────────────────────────────────────
+
+measure_mvn "tika-core"          "tika/tika-core"
+measure_mvn "tika-serialization" "tika/tika-serialization"
+measure_mvn "tika-parser-pdf"    "$TIKA_PARSERS/tika-parser-pdf-module"
+measure_mvn "tika-parser-msft"   "$TIKA_PARSERS/tika-parser-microsoft-module"
+measure_mvn "tika-parser-image"  "$TIKA_PARSERS/tika-parser-image-module"
+measure_mvn "tika-parser-pkg"    "$TIKA_PARSERS/tika-parser-pkg-module"
+measure_mvn "tika-parser-code"   "$TIKA_PARSERS/tika-parser-code-module"
+measure_mvn "tika-parser-av"     "$TIKA_PARSERS/tika-parser-audiovideo-module"
+measure_mvn "tika-parser-misc"   "$TIKA_PARSERS/tika-parser-miscoffice-module"
+measure_mvn "tika-parser-apple"  "$TIKA_PARSERS/tika-parser-apple-module"
+measure_mvn "tika-parser-web"    "$TIKA_PARSERS/tika-parser-webarchive-module"
+measure_mvn "tika-parser-crypto" "$TIKA_PARSERS/tika-parser-crypto-module"
+measure_mvn "tika-parser-cad"    "$TIKA_PARSERS/tika-parser-cad-module"
+measure_mvn "tika-parser-font"   "$TIKA_PARSERS/tika-parser-font-module"
+measure_mvn "tika-parser-news"   "$TIKA_PARSERS/tika-parser-news-module"
+measure_mvn "tika-parsers-pkg"   "tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-package"
+
+# ── Merge step ────────────────────────────────────────────────────────────────
+
+JAR="tika/tika-app/target/tika-app-3.3.1.jar"
+[[ -f "$JAR" ]] || { log "SKIP merge — $JAR not found"; exit 0; }
+
+CACHE_PATHS=(
+  "tika/tika-core/cache.aot"
+  "tika/tika-serialization/cache.aot"
+  "$TIKA_PARSERS/tika-parser-pdf-module/cache.aot"
+  "$TIKA_PARSERS/tika-parser-microsoft-module/cache.aot"
+  "$TIKA_PARSERS/tika-parser-image-module/cache.aot"
+  "$TIKA_PARSERS/tika-parser-pkg-module/cache.aot"
+  "$TIKA_PARSERS/tika-parser-code-module/cache.aot"
+  "$TIKA_PARSERS/tika-parser-audiovideo-module/cache.aot"
+  "$TIKA_PARSERS/tika-parser-miscoffice-module/cache.aot"
+  "$TIKA_PARSERS/tika-parser-apple-module/cache.aot"
+  "$TIKA_PARSERS/tika-parser-webarchive-module/cache.aot"
+  "$TIKA_PARSERS/tika-parser-crypto-module/cache.aot"
+  "$TIKA_PARSERS/tika-parser-cad-module/cache.aot"
+  "$TIKA_PARSERS/tika-parser-font-module/cache.aot"
+  "$TIKA_PARSERS/tika-parser-news-module/cache.aot"
+  "tika/tika-parsers/tika-parsers-standard/tika-parsers-standard-package/cache.aot"
+)
+
+for p in "${CACHE_PATHS[@]}"; do
+  [[ -f "$p" ]] || { log "SKIP merge — missing $p"; exit 0; }
+done
+
+BASE_AOT="${CACHE_PATHS[0]}"
+MERGE_INPUTS="$(IFS=:; echo "${CACHE_PATHS[*]}")"
+
+info "[merge] assembling tree.aot"
+rm -f tree.aot
+timed java \
+  -Xlog:aot=info \
+  -Xlog:aot+map=trace,aot+map+oops=trace,aot=warning:file=aot.map:none:filesize=0 \
+  -Djava.awt.headless=true \
+  -XX:AOTMode=merge \
+  -XX:AOTCache="$BASE_AOT" \
+  -XX:AOTMergeInputs="$MERGE_INPUTS" \
+  -XX:AOTCacheOutput=tree.aot \
+  -cp "$JAR" \
+  -version
+echo "merge,0,$LAST_MS,N/A" | tee -a "$CSV"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+log "=== Summary ==="
+awk -F, 'NR==1{print; next}
+  $1!="merge"{base+=$2; cache+=$3}
+  $1=="merge"{merge=$3}
+  END{
+    printf "total baseline : %d ms\ntotal with-cache: %d ms\noverhead        : %.1f%%\n",
+      base, cache+merge, 100*(cache+merge-base)/base
+  }' "$CSV"

--- a/tika-experiment/measure-build-overhead.sh
+++ b/tika-experiment/measure-build-overhead.sh
@@ -32,6 +32,9 @@ measure_mvn() {
     local label="$1" dir="$2"; shift 2
     local t_base t_cache ovhd
 
+    info "[$label] warmup (populate Maven local repo)"
+    sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -P '!tree-merge' $* || true"
+
     info "[$label] baseline"
     rm -f "$dir/cache.aot"
     timed sh -c "cd '$dir' && mvn clean test -B -Drat.skip=true -P '!tree-merge' $* || true"


### PR DESCRIPTION
## Summary

Adds `measure-build-overhead.sh` to each tree-combine experiment directory to collect the data needed for RQ1 (build-time overhead of tree-cache production).

## Changes

- **8 new scripts**, one per experiment: `batik`, `biojava`, `commons-compress`, `commons-configuration`, `commons-validator`, `opennlp`, `thymeleaf`, `tika`
- Each script measures wall-clock time for two passes per component:
  - **Baseline**: `mvn clean test -B -Drat.skip=true -P '!tree-merge'` — normal build, no cache produced
  - **Cache**: `mvn clean test -B -Drat.skip=true -Ptree-merge` — build with AOT cache production
- **Workload-only components** (facade libs with no test suite: commons-logging, xml-apis, xml-apis-ext, unbescape, forester) use `java -jar fat.jar` vs `java -XX:AOTCacheOutput=... -jar fat.jar`
- **Merge step** is timed separately (tree.aot assembly via `java -XX:AOTMode=merge`)
- Output: `build-overhead.csv` with `component,baseline_ms,cache_ms,overhead_pct` and a final total summary

## Special cases handled

- `slf4j-api` (thymeleaf, biojava): tree-merge profile has `<activation><jdk>[17,)</jdk></activation>` — baseline explicitly uses `-P '!tree-merge'` to suppress auto-activation
- `commons-validator/commons-logging`: submodule currently on wrong branch (`fop-experiment` instead of `aotcache-setup-commons-validator`) — script warns and auto-detects fat jar name, skips gracefully if not found
- `opennlp`, `tika`: multi-module projects — includes prerequisite note to run `mvn install -DskipTests` at the parent level first

## Testing

Run any script from its experiment directory:

```bash
cd batik-experiment && ./measure-build-overhead.sh
# → build-overhead.csv + printed summary
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)