### PR TITLE
Add PDFBox tree-iterative AOT cache experiment

### DIFF
--- a/.github/workflows/pdfbox-tree-iterative-aot.yml
+++ b/.github/workflows/pdfbox-tree-iterative-aot.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           set -euo pipefail
           chmod +x create-single-aot-iterjdk.sh
-          JAVA_BIN="$TREE_ITER_JAVA_HOME/bin/java" ./create-single-aot-iterjdk.sh
+          JAVA_BIN="$TEMURIN_JAVA_HOME/bin/java" ./create-single-aot-iterjdk.sh
           for op in export-text export-images render fromtext split merge decode overlay; do
             test -f "single-iterjdk-${op}.aot"
           done

--- a/.github/workflows/pdfbox-tree-iterative-aot.yml
+++ b/.github/workflows/pdfbox-tree-iterative-aot.yml
@@ -1,0 +1,176 @@
+name: PDFBox Tree-Iterative AOT Cache
+
+on:
+  workflow_dispatch:
+
+jobs:
+  tree-iterative-aot:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          submodules: true
+
+      # ── JDK setup ─────────────────────────────────────────────────────────
+
+      - name: Download tree-iterative JDK
+        run: |
+          curl -L -o jdk-tree-iter.tar.gz \
+            "https://github.com/algomaster99/jdk/releases/download/jdk-supply-chain-aotcache-2d171b420a0/jdk-supply-chain-aotcache-2d171b420a0.tar.gz"
+
+      - name: Set up tree-iterative JDK
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: jdkfile
+          java-version: '25'
+          jdkFile: jdk-tree-iter.tar.gz
+
+      - name: Capture tree-iterative JDK path
+        run: echo "TREE_ITER_JAVA_HOME=$JAVA_HOME" >> "$GITHUB_ENV"
+
+      - name: Set up JDK 25 (no-AOT baseline and single.aot)
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: temurin
+          java-version: '25'
+
+      - name: Capture Temurin JDK path
+        run: echo "TEMURIN_JAVA_HOME=$JAVA_HOME" >> "$GITHUB_ENV"
+
+      # ── Maven cache ────────────────────────────────────────────────────────
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-pdfbox-tree-iter-${{ hashFiles('pdfbox-experiment/**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-pdfbox-tree-iter-
+            ${{ runner.os }}-maven-
+
+      # ── build pdfbox ───────────────────────────────────────────────────────
+
+      - name: Re-enable tree-iterative JDK for Maven build
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: jdkfile
+          java-version: '25'
+          jdkFile: jdk-tree-iter.tar.gz
+
+      - name: Build pdfbox app jar
+        working-directory: pdfbox-experiment/pdfbox
+        run: mvn package -DskipTests -q
+
+      # ── single-iterjdk-*.aot (cross-workload, tree-iterative JDK) ─────────
+
+      - name: Create single-iterjdk-*.aot caches
+        working-directory: pdfbox-experiment
+        run: |
+          set -euo pipefail
+          chmod +x create-single-aot-iterjdk.sh
+          JAVA_BIN="$TREE_ITER_JAVA_HOME/bin/java" ./create-single-aot-iterjdk.sh
+          for op in export-text export-images render fromtext split merge decode overlay; do
+            test -f "single-iterjdk-${op}.aot"
+          done
+
+      # ── iterative-tree.aot (pdfbox reactor only: io → fontbox → pdfbox → tools) ──
+
+      - name: Build pdfbox reactor iterative chain
+        working-directory: pdfbox-experiment/pdfbox
+        run: |
+          set -euo pipefail
+          find . -name "iter.aot" -delete
+          mvn clean test -Piterative-merge -pl io,fontbox,pdfbox,tools -q
+          test -f tools/iter.aot
+
+      - name: Finalise iterative-tree.aot
+        working-directory: pdfbox-experiment
+        run: |
+          cp pdfbox/tools/iter.aot iterative-tree.aot
+          echo "iterative-tree.aot: $(du -h iterative-tree.aot | awk '{print $1}')"
+
+      # ── timed workload ─────────────────────────────────────────────────────
+
+      - name: Run timed workload (no vs aotcache vs tree-iter)
+        working-directory: pdfbox-experiment
+        run: |
+          set -euo pipefail
+          chmod +x workload-timed-tree-iterative.sh
+          wl_out=$(JAVA_NO_BIN="$TEMURIN_JAVA_HOME/bin/java" \
+                   JAVA_AOTCACHE_BIN="$TEMURIN_JAVA_HOME/bin/java" \
+                   JAVA_TREE_ITER_BIN="$TREE_ITER_JAVA_HOME/bin/java" \
+                   ./workload-timed-tree-iterative.sh 2>&1) || { echo "$wl_out"; exit 1; }
+          echo "$wl_out"
+          wl_out_clean=$(echo "$wl_out" | sed 's/\x1B\[[0-9;]*m//g')
+
+          single_size=$(du -ch single-iterjdk-*.aot | tail -1 | awk '{print $1}')
+          tree_iter_size=$(du -h iterative-tree.aot | awk '{print $1}')
+
+          {
+            echo "## Timed workload results (no vs cross-workload aotcache vs tree-iter)"
+            echo
+            echo "- single-iterjdk-*.aot total: ${single_size}"
+            echo "- iterative-tree.aot: ${tree_iter_size}"
+            echo
+            echo '```'
+            echo "$wl_out_clean"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Append LaTeX table rows to summary
+        working-directory: pdfbox-experiment
+        run: |
+          {
+            echo "## LaTeX table rows"
+            echo
+            echo '```latex'
+            cat workload-tmp/latex-rows-tree-iter.tex
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Append class-load breakdown to summary
+        working-directory: pdfbox-experiment
+        run: |
+          {
+            echo "## Class-load breakdown (file: vs shared object)"
+            echo
+            echo '```'
+            grep -E "Operation|file:|shared|────" workload-tmp/latex-rows-tree-iter.tex || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # ── artifact summary ───────────────────────────────────────────────────
+
+      - name: Write artifact summary
+        working-directory: pdfbox-experiment
+        run: |
+          {
+            echo "## AOT cache sizes"
+            echo
+            echo "| Cache | Size |"
+            echo "|---|---|"
+            for op in export-text export-images render fromtext split merge decode overlay; do
+              echo "| \`single-iterjdk-${op}.aot\` | $(du -h "single-iterjdk-${op}.aot" | awk '{print $1}') |"
+            done
+            for f in pdfbox/io/iter.aot pdfbox/fontbox/iter.aot pdfbox/pdfbox/iter.aot pdfbox/tools/iter.aot; do
+              echo "| \`${f}\` | $(du -h "$f" | awk '{print $1}') |"
+            done
+            echo "| \`iterative-tree.aot\` | $(du -h iterative-tree.aot | awk '{print $1}') |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # ── upload ─────────────────────────────────────────────────────────────
+
+      - name: Upload PDFBox tree-iterative artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: pdfbox-tree-iterative-artifacts
+          path: |
+            pdfbox-experiment/workload-tmp/
+            pdfbox-experiment/single-iterjdk-*.aot
+            pdfbox-experiment/pdfbox/io/iter.aot
+            pdfbox-experiment/pdfbox/fontbox/iter.aot
+            pdfbox-experiment/pdfbox/pdfbox/iter.aot
+            pdfbox-experiment/pdfbox/tools/iter.aot
+            pdfbox-experiment/iterative-tree.aot
+          if-no-files-found: error

--- a/.github/workflows/pdfbox-tree-iterative-aot.yml
+++ b/.github/workflows/pdfbox-tree-iterative-aot.yml
@@ -1,6 +1,9 @@
 name: PDFBox Tree-Iterative AOT Cache
 
 on:
+  push:
+    branches: [main]
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pdfbox-tree-iterative-aot.yml
+++ b/.github/workflows/pdfbox-tree-iterative-aot.yml
@@ -103,6 +103,7 @@ jobs:
           wl_out=$(JAVA_NO_BIN="$TEMURIN_JAVA_HOME/bin/java" \
                    JAVA_AOTCACHE_BIN="$TEMURIN_JAVA_HOME/bin/java" \
                    JAVA_TREE_ITER_BIN="$TREE_ITER_JAVA_HOME/bin/java" \
+                   RUNS=1 \
                    ./workload-timed-tree-iterative.sh 2>&1) || { echo "$wl_out"; exit 1; }
           echo "$wl_out"
           wl_out_clean=$(echo "$wl_out" | sed 's/\x1B\[[0-9;]*m//g')

--- a/.github/workflows/pdfbox-tree-iterative-aot.yml
+++ b/.github/workflows/pdfbox-tree-iterative-aot.yml
@@ -103,7 +103,6 @@ jobs:
           wl_out=$(JAVA_NO_BIN="$TEMURIN_JAVA_HOME/bin/java" \
                    JAVA_AOTCACHE_BIN="$TEMURIN_JAVA_HOME/bin/java" \
                    JAVA_TREE_ITER_BIN="$TREE_ITER_JAVA_HOME/bin/java" \
-                   RUNS=1 \
                    ./workload-timed-tree-iterative.sh 2>&1) || { echo "$wl_out"; exit 1; }
           echo "$wl_out"
           wl_out_clean=$(echo "$wl_out" | sed 's/\x1B\[[0-9;]*m//g')

--- a/pdfbox-experiment/create-iterative-aot-deps.sh
+++ b/pdfbox-experiment/create-iterative-aot-deps.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Continues the iterative AOT chain from pdfbox/tools/iter.aot through the
+# third-party dependency workloads, in dependency-tree order:
+#
+#   pdfbox-app (already in pdfbox reactor chain)
+#     └─ bcpkix → bcutil  (train bcutil first, bcpkix after)
+#     └─ bcprov           (independent of bcpkix/bcutil)
+#     └─ commons-logging  (independent)
+#     └─ commons-io       (no workload project — skipped)
+#     └─ jbig2-imageio    (no workload project — skipped)
+#
+# Prerequisites:
+#   1. Run the pdfbox reactor chain first to produce pdfbox/tools/iter.aot:
+#        cd pdfbox && mvn clean test -Piterative-merge -pl io,fontbox,pdfbox,tools
+#   2. Build all dep fat jars (only needed once):
+#        (cd pdfbox-deps/bc-java-util-workload && mvn package -q)
+#        (cd pdfbox-deps/bc-java-prov-workload  && mvn package -q)
+#        (cd pdfbox-deps/bc-java-pkix-workload  && mvn package -q)
+#        (cd pdfbox-deps/commons-logging-workload && mvn package -q)
+#
+# Usage:
+#   JAVA_BIN=<aot-re-jdk>/bin/java ./create-iterative-aot-deps.sh
+set -euo pipefail
+
+log()  { echo -e "\033[1;32m[$(date '+%H:%M:%S')] $*\033[0m"; }
+fail() { echo -e "\033[1;31mERROR: $*\033[0m" >&2; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+JAVA_BIN="${JAVA_BIN:-java}"
+log "Java binary: $JAVA_BIN"
+"$JAVA_BIN" -version
+
+# ── Starting point: final output of the pdfbox reactor chain ──────────────────
+PREV_AOT="pdfbox/tools/iter.aot"
+[[ -f "$PREV_AOT" ]] || fail "Starting cache not found: $PREV_AOT — run pdfbox reactor first."
+
+# ── Dep chain steps ───────────────────────────────────────────────────────────
+# Each entry: "<dep-dir>:<artifact-id>"
+# Order: dependencies before dependents
+#   bcutil is a dep of bcpkix → train bcutil first via bc-java-util-workload
+#   bcprov is independent but used by bcutil workload's fat jar → train next
+#   bcpkix depends on bcutil + bcprov → train last among BC
+#   commons-logging is independent
+STEPS=(
+    "pdfbox-deps/bc-java-util-workload:bc-java-util-workload-1.0-SNAPSHOT"
+    "pdfbox-deps/bc-java-prov-workload:bc-java-prov-workload-1.0-SNAPSHOT"
+    "pdfbox-deps/bc-java-pkix-workload:bc-java-pkix-workload-1.0-SNAPSHOT"
+    "pdfbox-deps/commons-logging-workload:commons-logging-workload-1.0-SNAPSHOT"
+)
+
+for step in "${STEPS[@]}"; do
+    dir="${step%%:*}"
+    jar_base="${step##*:}"
+    jar="$SCRIPT_DIR/$dir/target/${jar_base}.jar"
+    out_aot="$SCRIPT_DIR/$dir/iter.aot"
+
+    [[ -d "$SCRIPT_DIR/$dir" ]] || fail "Dep directory not found: $dir"
+    [[ -f "$jar" ]] || fail "Fat jar not found: $jar — run 'mvn package' in $dir first"
+
+    if [[ -f "$out_aot" ]]; then
+        log "$out_aot already exists, skipping."
+        PREV_AOT="$out_aot"
+        continue
+    fi
+
+    log "Folding $dir (base: $PREV_AOT) → $out_aot"
+    "$JAVA_BIN" \
+        -XX:AOTCache="$PREV_AOT" \
+        -XX:AOTCacheOutput="$out_aot" \
+        -XX:+AOTClassLinking \
+        -cp "$jar" \
+        com.example.App
+
+    [[ -f "$out_aot" ]] || fail "$out_aot was not created"
+    log "$out_aot created ($(du -sh "$out_aot" | cut -f1))"
+    PREV_AOT="$out_aot"
+done
+
+cp -f "$PREV_AOT" iterative-tree.aot
+log "Final iterative cache: iterative-tree.aot ($(du -sh iterative-tree.aot | cut -f1))"

--- a/pdfbox-experiment/workload-timed-tree-iterative.sh
+++ b/pdfbox-experiment/workload-timed-tree-iterative.sh
@@ -1,0 +1,291 @@
+#!/bin/bash
+# Timing comparison for the dep-chain iterative AOT cache (iterative-tree.aot).
+# Three modes per workload:
+#
+#   no           — no AOT cache (plain JDK baseline)
+#   aotcache     — single-iterjdk-{train_op}.aot cross-workload: cache trained
+#                  on one op, run on all other ops, mean taken over the others
+#   iterative-tree — iterative-tree.aot built by create-iterative-aot-deps.sh
+#                    (pdfbox reactor iterative chain → bc deps → commons-logging)
+#
+# Usage:
+#   JAVA_BIN=<aot-re-jdk>/bin/java RUNS=30 ./workload-timed-tree-iterative.sh
+set -euo pipefail
+
+log()  { echo -e "\033[1;32m[$(date '+%H:%M:%S')] $*\033[0m"; }
+sep()  { echo -e "\033[0;90m  $(printf '─%.0s' {1..60})\033[0m"; }
+fail() { echo -e "\033[1;31mERROR: $*\033[0m" >&2; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+JAVA_NO_BIN="${JAVA_NO_BIN:-${JAVA_BIN:-java}}"
+JAVA_AOTCACHE_BIN="${JAVA_AOTCACHE_BIN:-${JAVA_BIN:-java}}"
+JAVA_TREE_ITER_BIN="${JAVA_TREE_ITER_BIN:-${JAVA_BIN:-java}}"
+JAR="pdfbox/app/target/pdfbox-app-3.0.7.jar"
+MAIN="org.apache.pdfbox.tools.PDFBox"
+PDF="pdfbox/test.pdf"
+BASE="tree-iter"
+TMP="workload-tmp"
+TREE_ITER_AOT="iterative-tree.aot"
+RUNS="${RUNS:-30}"
+OPS=(export:text export:images render fromtext split merge decode overlay)
+
+[[ -f "$JAR" ]]           || fail "$JAR not found — build pdfbox first"
+[[ -f "$PDF" ]]           || fail "$PDF not found"
+[[ -f "$TREE_ITER_AOT" ]] || fail "$TREE_ITER_AOT not found — run create-iterative-aot-deps.sh first"
+for _op in "${OPS[@]}"; do
+  [[ -f "single-iterjdk-${_op//:/-}.aot" ]] \
+    || fail "single-iterjdk-${_op//:/-}.aot not found — run create-single-aot-iterjdk.sh first"
+done
+
+mkdir -p "$TMP"
+
+log "Java binaries:"
+printf "  no:          %s\n" "$JAVA_NO_BIN";       "$JAVA_NO_BIN"       -version 2>&1 | head -1
+printf "  aotcache:    %s\n" "$JAVA_AOTCACHE_BIN"; "$JAVA_AOTCACHE_BIN" -version 2>&1 | head -1
+printf "  tree-iter:   %s\n" "$JAVA_TREE_ITER_BIN"; "$JAVA_TREE_ITER_BIN" -version 2>&1 | head -1
+echo
+
+# ─── op args ─────────────────────────────────────────────────────────────────
+
+op_args() {
+  local op="$1"
+  local -n _arr="$2"
+  case "$op" in
+    export:text)   _arr=(export:text   --input "$PDF" --output "$TMP/$BASE-text.txt") ;;
+    export:images) _arr=(export:images --input "$PDF") ;;
+    render)        _arr=(render        --input "$PDF") ;;
+    fromtext)      _arr=(fromtext      --input "$TMP/$BASE-text.txt"
+                           --output "$TMP/$BASE-from-text.pdf"
+                           -standardFont Times-Roman) ;;
+    split)         _arr=(split         --input "$PDF" -split 3 -outputPrefix "$TMP/split-$BASE") ;;
+    merge)         _arr=(merge         --input "$TMP/split-$BASE-1.pdf"
+                           --output "$TMP/merged-$BASE.pdf") ;;
+    decode)        _arr=(decode "$PDF" "$TMP/$BASE-decoded.pdf") ;;
+    overlay)       _arr=(overlay       -default "$PDF" --input "$PDF"
+                           --output "$TMP/$BASE-overlay.pdf") ;;
+    *) fail "Unknown op: $op" ;;
+  esac
+}
+
+log "Preparing prerequisite files…"
+"$JAVA_NO_BIN" -cp "$JAR" "$MAIN" export:text --input "$PDF" --output "$TMP/$BASE-text.txt" >/dev/null 2>&1
+"$JAVA_NO_BIN" -cp "$JAR" "$MAIN" split --input "$PDF" -split 3 -outputPrefix "$TMP/split-$BASE" >/dev/null 2>&1
+
+# ─── runners ─────────────────────────────────────────────────────────────────
+
+run_no() {
+  local op="$1"; local -a args; op_args "$op" args
+  "$JAVA_NO_BIN" -cp "$JAR" "$MAIN" "${args[@]}"
+}
+
+run_aotcache_cross() {
+  local train_op="$1" test_op="$2"; local -a args; op_args "$test_op" args
+  "$JAVA_AOTCACHE_BIN" -XX:AOTCache="single-iterjdk-${train_op//:/-}.aot" -XX:+AOTClassLinking \
+    -cp "$JAR" "$MAIN" "${args[@]}"
+}
+
+run_tree_iter() {
+  local op="$1"; local -a args; op_args "$op" args
+  "$JAVA_TREE_ITER_BIN" -XX:AOTCache="$TREE_ITER_AOT" -XX:+AOTClassLinking \
+    -cp "$JAR" "$MAIN" "${args[@]}"
+}
+
+# ─── timing helpers ──────────────────────────────────────────────────────────
+
+ms() { date +%s%N | awk '{printf "%.1f", $1/1000000}'; }
+
+declare -A _samples
+
+_update() {
+  local key="$1" v="$2"
+  _samples[$key]="${_samples[$key]:-} $v"
+}
+
+_mean() {
+  printf "%s\n" ${_samples[$1]:-} | awk \
+    '{sum+=$1; n++} END{if(!n){print "n/a"}else{printf "%.1f",sum/n}}'
+}
+
+_stddev() {
+  printf "%s\n" ${_samples[$1]:-} | awk \
+    '{sum+=$1; sumsq+=$1*$1; n++}
+     END{if(n<2){print "n/a"}else{printf "%.1f",sqrt((sumsq-sum*sum/n)/(n-1))}}'
+}
+
+_measure() {
+  local key="$1" label="$2"; shift 2
+  local safe="${label//:/-}"; safe="${safe//>/-}"
+  local errfile="$TMP/${RUN_IDX:-0}-${safe}.stderr.log"
+  local t0 t1 rc=0
+  t0=$(ms); "$@" >/dev/null 2>"$errfile" || rc=$?; t1=$(ms)
+  if (( rc != 0 )); then
+    echo "  WARN: $label exited $rc — see $errfile" >&2; return
+  fi
+  _update "$key" "$(awk "BEGIN{printf \"%.1f\",$t1-$t0}")"
+}
+
+# Mean of test_op times over all caches trained on ≠ test_op.
+_aotcache_cross_mean() {
+  local test_op="$1" sum=0 n=0 train_op m
+  for train_op in "${OPS[@]}"; do
+    [[ "$train_op" == "$test_op" ]] && continue
+    m=$(_mean "${train_op}|${test_op}|aotcache")
+    sum=$(awk "BEGIN{printf \"%.4f\",$sum+$m}")
+    n=$(( n+1 ))
+  done
+  awk -v s="$sum" -v n="$n" 'BEGIN{printf "%.1f",s/n}'
+}
+
+# Pooled SD of test_op across all cross-workload caches.
+_aotcache_cross_stddev() {
+  local test_op="$1" all="" train_op
+  for train_op in "${OPS[@]}"; do
+    [[ "$train_op" == "$test_op" ]] && continue
+    all="$all ${_samples[${train_op}|${test_op}|aotcache]:-}"
+  done
+  printf "%s\n" $all | awk \
+    '{sum+=$1; sumsq+=$1*$1; n++}
+     END{if(n<2){print "n/a"}else{printf "%.1f",sqrt((sumsq-sum*sum/n)/(n-1))}}'
+}
+
+# ─── main measurement loop ────────────────────────────────────────────────────
+
+log "Running PDFBox tree-iterative workload experiment — RUNS=$RUNS"
+sep
+
+for RUN_IDX in $(seq 1 "$RUNS"); do
+  printf "  run %2d/%d\n" "$RUN_IDX" "$RUNS"
+  for op in "${OPS[@]}"; do
+    _measure "${op}|no"        "no:$op"        run_no        "$op"
+    _measure "${op}|tree-iter" "tree-iter:$op" run_tree_iter "$op"
+  done
+  for train_op in "${OPS[@]}"; do
+    for test_op in "${OPS[@]}"; do
+      [[ "$test_op" == "$train_op" ]] && continue
+      _measure "${train_op}|${test_op}|aotcache" "aotcache:${train_op}>${test_op}" \
+        run_aotcache_cross "$train_op" "$test_op"
+    done
+  done
+done
+
+# ─── results table ───────────────────────────────────────────────────────────
+
+echo
+log "Per-workload timing over ${RUNS} runs (ms)"
+sep
+printf "  %-16s | %18s | %20s %8s | %22s %10s\n" \
+  "Workload" "no (mean±SD)" "aotcache (mean±SD)" "su-aot" "tree-iter (mean±SD)" "su-tree-iter"
+sep
+for op in "${OPS[@]}"; do
+  m_no=$(_mean "${op}|no")
+  m_ac=$(_aotcache_cross_mean "$op")
+  m_ti=$(_mean "${op}|tree-iter")
+  sd_no=$(_stddev "${op}|no")
+  sd_ac=$(_aotcache_cross_stddev "$op")
+  sd_ti=$(_stddev "${op}|tree-iter")
+  su_ac=$(awk -v b="$m_no" -v a="$m_ac" 'BEGIN{if(a+0==0){print "n/a"}else{printf "%.2fx",b/a}}')
+  su_ti=$(awk -v b="$m_no" -v a="$m_ti" 'BEGIN{if(a+0==0){print "n/a"}else{printf "%.2fx",b/a}}')
+  printf "  %-16s | %18s | %20s %8s | %22s %10s\n" \
+    "$op" "${m_no}±${sd_no}" "${m_ac}±${sd_ac}" "$su_ac" "${m_ti}±${sd_ti}" "$su_ti"
+done
+
+# ─── LaTeX rows ──────────────────────────────────────────────────────────────
+
+_latex_rows() {
+  local project="$1"
+  local n="${#OPS[@]}"
+  local tex_file="$TMP/latex-rows-tree-iter.tex"
+  local sum_su_ac=0 sum_su_ti=0
+  echo "\\multirow{$(( n+1 ))}{*}{${project}}" > "$tex_file"
+  local op
+  for op in "${OPS[@]}"; do
+    local m_no m_ac m_ti sd_no sd_ac sd_ti su_ac su_ti fmt_ac fmt_ti
+    m_no=$(_mean "${op}|no");      sd_no=$(_stddev "${op}|no")
+    m_ac=$(_aotcache_cross_mean "$op"); sd_ac=$(_aotcache_cross_stddev "$op")
+    m_ti=$(_mean "${op}|tree-iter"); sd_ti=$(_stddev "${op}|tree-iter")
+    su_ac=$(awk -v b="$m_no" -v a="$m_ac" 'BEGIN{if(a+0==0){print "0"}else{printf "%.2f",b/a}}')
+    su_ti=$(awk -v b="$m_no" -v a="$m_ti" 'BEGIN{if(a+0==0){print "0"}else{printf "%.2f",b/a}}')
+    sum_su_ac=$(awk "BEGIN{printf \"%.4f\",$sum_su_ac+$su_ac}")
+    sum_su_ti=$(awk "BEGIN{printf \"%.4f\",$sum_su_ti+$su_ti}")
+    fmt_ac=$(awk -v a="$su_ac" -v b="$su_ti" 'BEGIN{if(a+0>b+0){print "\\textbf{"a"x}"}else{print a"x"}}')
+    fmt_ti=$(awk -v a="$su_ac" -v b="$su_ti" 'BEGIN{if(b+0>a+0){print "\\textbf{"b"x}"}else{print b"x"}}')
+    echo "  & ${op} & \$${m_no}\\pm${sd_no}\$ & \$${m_ac}\\pm${sd_ac}\$ & ${fmt_ac} & \$${m_ti}\\pm${sd_ti}\$ & ${fmt_ti} \\\\" \
+      >> "$tex_file"
+  done
+  local avg_ac avg_ti fmt_avg_ac fmt_avg_ti
+  avg_ac=$(awk -v s="$sum_su_ac" -v n="$n" 'BEGIN{printf "%.2f",s/n}')
+  avg_ti=$(awk -v s="$sum_su_ti" -v n="$n" 'BEGIN{printf "%.2f",s/n}')
+  fmt_avg_ac=$(awk -v a="$avg_ac" -v b="$avg_ti" 'BEGIN{if(a+0>b+0){print "\\textbf{"a"x}"}else{print a"x"}}')
+  fmt_avg_ti=$(awk -v a="$avg_ac" -v b="$avg_ti" 'BEGIN{if(b+0>a+0){print "\\textbf{"b"x}"}else{print b"x"}}')
+  echo "  & \\textit{Average} & & & ${fmt_avg_ac} & & ${fmt_avg_ti} \\\\" >> "$tex_file"
+  echo "\\midrule" >> "$tex_file"
+}
+
+_latex_rows "pdfbox"
+
+# ─── class-load breakdown ────────────────────────────────────────────────────
+
+_classload_row() {
+  local mode="$1" op="$2"
+  local safe="${op//:/-}"
+  local logfile="$TMP/cl-${safe}-${mode}.log"
+  local -a args; op_args "$op" args
+  case "$mode" in
+    no)
+      "$JAVA_NO_BIN" -Xlog:class+load:file="$logfile" \
+        -cp "$JAR" "$MAIN" "${args[@]}" >/dev/null 2>&1
+      ;;
+    aotcache)
+      "$JAVA_AOTCACHE_BIN" -XX:AOTCache="single-iterjdk-${safe}.aot" -XX:+AOTClassLinking \
+        -Xlog:class+load:file="$logfile" \
+        -cp "$JAR" "$MAIN" "${args[@]}" >/dev/null 2>&1
+      ;;
+    tree-iter)
+      "$JAVA_TREE_ITER_BIN" -XX:AOTCache="$TREE_ITER_AOT" -XX:+AOTClassLinking \
+        -Xlog:class+load:file="$logfile" \
+        -cp "$JAR" "$MAIN" "${args[@]}" >/dev/null 2>&1
+      ;;
+  esac
+  printf "  %-16s | %-10s | %8s | %8s\n" "$op" "$mode" \
+    "$(awk '/source: file:/{c++} END{print c+0}' "$logfile")" \
+    "$(awk '/source: shared object/{c++} END{print c+0}' "$logfile")"
+}
+
+echo
+log "Class-load source breakdown (aotcache uses same-workload cache)"
+sep
+printf "  %-16s | %-10s | %8s | %8s\n" "Operation" "Mode" "file:" "shared"
+sep
+for op in "${OPS[@]}"; do
+  _classload_row no        "$op"
+  _classload_row aotcache  "$op"
+  _classload_row tree-iter "$op"
+  sep
+done
+
+# ─── cache size table ────────────────────────────────────────────────────────
+
+echo
+log "Cache sizes"
+sep
+printf "  %-44s | %10s\n" "Cache" "Size"
+sep
+for op in "${OPS[@]}"; do
+  safe="${op//:/-}"
+  printf "  %-44s | %10s\n" "single-iterjdk-${safe}.aot" \
+    "$(du -h "single-iterjdk-${safe}.aot" 2>/dev/null | awk '{print $1}' || echo n/a)"
+done
+for f in pdfbox/io/iter.aot pdfbox/fontbox/iter.aot pdfbox/pdfbox/iter.aot pdfbox/tools/iter.aot \
+         pdfbox-deps/bc-java-util-workload/iter.aot \
+         pdfbox-deps/bc-java-prov-workload/iter.aot \
+         pdfbox-deps/bc-java-pkix-workload/iter.aot \
+         pdfbox-deps/commons-logging-workload/iter.aot; do
+  [[ -f "$f" ]] || continue
+  printf "  %-44s | %10s\n" "$f" "$(du -h "$f" | awk '{print $1}')"
+done
+printf "  %-44s | %10s\n" "$TREE_ITER_AOT" "$(du -h "$TREE_ITER_AOT" | awk '{print $1}')"
+
+echo
+log "Done. LaTeX rows → $TMP/latex-rows-tree-iter.tex"


### PR DESCRIPTION
Adds an iterative-training approach for the PDFBox AOT cache where each module in the Maven reactor folds its test-suite classes into the cache from the previous step (io → fontbox → pdfbox → tools), producing iterative-tree.aot as the final cumulative cache.

Three-mode workload compares: no-AOT baseline (Temurin 25), cross-workload single-iterjdk.aot, and the new iterative-tree.aot (custom JDK). Fixes the log4j-api runtime crash by embedding it in pdfbox-app and pinning commons-logging to Jdk14Logger during recording.